### PR TITLE
Fix detect overlap

### DIFF
--- a/borsar/tests/test_utils.py
+++ b/borsar/tests/test_utils.py
@@ -39,4 +39,15 @@ def test_detect_overlap():
     seg = [5, 12]
     ann = np.array([[3, 6], [7, 9], [11, 12]])
     correct_overlap = (1 + 2 + 1) / np.diff(seg)
-    assert(detect_overlap(seg, ann, samples=True), correct_overlap)
+    assert(detect_overlap(seg, ann, sfreq=1.) == correct_overlap)
+
+    # another test on samples - this time with mne.Annotation
+    sfreq, seg = 2., [10, 18]
+    descriptions = ['_BAD'] * 3
+    onsets = np.array([6, 9, 14]) / sfreq
+    durations = np.array([2, 3, 3]) / sfreq
+    annot = mne.Annotations(onsets, durations, descriptions)
+    correct_overlap = (2 + 3) / np.diff(seg)[0]
+    assert(detect_overlap(seg, annot, sfreq=sfreq) == correct_overlap)
+
+

--- a/borsar/tests/test_utils.py
+++ b/borsar/tests/test_utils.py
@@ -33,3 +33,10 @@ def test_detect_overlap():
     seg = [0.1, 1.1]
     ann = np.array([[0.3, 0.4], [0.55, 0.65], [0.7, 0.8]])
     almost_equal(detect_overlap(seg, ann), 0.3)
+
+    # test detect overlap in samples
+    # as in slices the last sample is not included
+    seg = [5, 12]
+    ann = np.array([[3, 6], [7, 9], [11, 12]])
+    correct_overlap = (1 + 2 + 1) / np.diff(seg)
+    assert(detect_overlap(seg, ann, samples=True), correct_overlap)

--- a/borsar/utils.py
+++ b/borsar/utils.py
@@ -3,7 +3,7 @@ import numpy as np
 
 def find_range(vec, ranges):
     '''
-    Find specified ranges in an ordered vector and retur them as slices.
+    Find specified ranges in an ordered vector and return them as slices.
 
     Parameters
     ----------
@@ -46,7 +46,7 @@ def get_info(inst):
         return inst.info
 
 
-def detect_overlap(segment, annot):
+def detect_overlap(segment, annot, samples=False):
     '''
     Detect what percentage of given segment is overlapping with bad annotations.
 
@@ -66,11 +66,20 @@ def detect_overlap(segment, annot):
     if not isinstance(annot, np.ndarray):
         # if we didn't get numpy array we assume it's mne.Annotation
         # and convert it to N x 2 (N x start, end) array:
-        annot_arr = np.hstack([annot.onset[:, np.newaxis],
-                               annot.onset[:, np.newaxis]
-                               + annot.duration])
+        onset = (annot.onset if not samples else
+                 np.round(annot.onset).astype('int'))
+        duration = (annot.duration if not samples else
+                    np.round(annot.duration).astype('int'))
+        annot_arr = np.hstack([onset[:, np.newaxis], onset[:, np.newaxis]
+                               + duration])
     else:
-        annot_arr = annot
+        if not samples:
+            annot_arr = annot
+        else:
+            in_samples = (annot.dtype is np.dtype('int64') or
+                          annot.dtype is np.dtype('int32'))
+            # FIXME - if not in_samples throw an error or issue a warning
+            annot_arr = annot if in_samples else np.round(annot).astype('int')
 
     # checks for boundary relationships
     ll_beleq = annot_arr[:, 0] <= segment[0]


### PR DESCRIPTION
Przekształcanie annotations na macierz było skopane. `onset[:, np.newaxis] + duration` powinno być `onset[:, np.newaxis] + duration[:, np.newaxis]` inaczej mamy broadcasting przy dodawaniu.