### PR TITLE
Enh add mass indices

### DIFF
--- a/borsar/cluster.py
+++ b/borsar/cluster.py
@@ -477,9 +477,11 @@ class Clusters(object):
             grouped together in a tuple.
         '''
         # TODO: add safety checks
+        has_space = (self.dimnames is not None and
+                     self.dimnames[0] in ['vert', 'chan'])
         if check_dims is None:
             check_dims = list(range(self.stat.ndim))
-        if ignore_space and 0 in check_dims:
+        if has_space and ignore_space and 0 in check_dims:
             check_dims.remove(0)
 
         limits = list()
@@ -490,7 +492,8 @@ class Clusters(object):
                 contrib = self.get_contribution(cluster_idx, along=dimname)
 
                 # curent method - start at max and extend
-                limits.append(_get_mass_range(contrib, mass))
+                adj = not (idx == 0 and has_space)
+                limits.append(_get_mass_range(contrib, mass, adjacent=adj))
             else:
                 limits.append(slice(None))
         return tuple(limits)
@@ -1000,27 +1003,54 @@ def _get_full_dimname(dimname):
     return dct[dimname] if dimname in dct else dimname
 
 
-def _get_mass_range(contrib, mass):
-    '''Find range that retains given mass (sum) of the contributions vector.'''
+def _get_mass_range(contrib, mass, adjacent=True):
+    '''Find range that retains given mass (sum) of the contributions vector.
+
+    Parameters
+    ----------
+    contrib : np.ndarray
+        Vector of contributions.
+    mass : float
+        Requested mass to retain.
+    adjacent : boolean
+        Whether to extend from the maximum point by adjacency or not.
+
+    Returns
+    -------
+    extent : slice or np.ndarray of int
+        Slice (when `adjacency=True`) or indices (when `adjacency=False`)
+        retaining the required mass.
+    '''
     contrib_len = contrib.shape[0]
     max_idx = np.argmax(contrib)
     current_mass = contrib[max_idx]
-    side_idx = np.array([max_idx, max_idx])
-    while current_mass < mass:
-        side_idx += [-1, +1]
-        vals = [0. if side_idx[0] < 0 else contrib[side_idx[0]],
-                0. if side_idx[1] + 1 >= contrib.shape[0]
-                else contrib[side_idx[1]]]
 
-        if sum(vals) == 0.:
-            side_idx += [+1, -1]
-            break
-        ord = np.argmax(vals)
-        current_mass += contrib[side_idx[ord]]
-        one_back = [+1, -1]
-        one_back[ord] = 0
-        side_idx += one_back
-    return slice(side_idx[0], side_idx[1] + 1)
+    if adjacent:
+        side_idx = np.array([max_idx, max_idx])
+        while current_mass < mass:
+            side_idx += [-1, +1]
+            vals = [0. if side_idx[0] < 0 else contrib[side_idx[0]],
+                    0. if side_idx[1] + 1 >= contrib.shape[0]
+                    else contrib[side_idx[1]]]
+
+            if sum(vals) == 0.:
+                side_idx += [+1, -1]
+                break
+            ord = np.argmax(vals)
+            current_mass += contrib[side_idx[ord]]
+            one_back = [+1, -1]
+            one_back[ord] = 0
+            side_idx += one_back
+
+        return slice(side_idx[0], side_idx[1] + 1)
+    else:
+        indices = np.argsort(contrib)[::-1]
+        cum_mass = np.cumsum(contrib[indices])
+        retains_mass = np.where(cum_mass >= mass)[0]
+        if len(retains_mass) > 0:
+            indices = indices[:retains_mass[0] + 1]
+        return np.sort(indices)
+
 
 
 def _cluster_selection(clst, sel):

--- a/borsar/tests/test_cluster.py
+++ b/borsar/tests/test_cluster.py
@@ -179,6 +179,34 @@ def test_index_from_dim():
             == (slice(None), slice(3, 5), slice(2, 6)))
 
 
+def test_cluster_limits():
+    T, F = True, False
+    use_contrib = np.array([0.25, 0.1, 0.38, 0.07, 0.15, 0.05, 0.1])
+    use_clusters = [np.array([T, F, T, T, T, F, T])]
+
+    clusters = np.zeros((7, 100), dtype='bool')
+    for idx, (cntrb, cl) in enumerate(zip(use_contrib, use_clusters[0])):
+        if cl:
+            clusters[idx, :int(cntrb * 100)] = True
+
+    pvals = [0.02]
+    stat = np.ones((7, 100))
+    info = mne.create_info(list('ABCDEFG'), sfreq=250.)
+    # FIX: dimcoords should not be necessary, but we get error without
+    dimcoords = [list('ABCDEFG'), np.linspace(3., 25., num=100)]
+    clst = Clusters([clusters], pvals, stat, dimnames=['chan', 'freq'],
+                    dimcoords=dimcoords, info=info)
+
+    lmts = clst.get_cluster_limits(0, retain_mass=0.66, ignore_space=False)
+    assert (lmts[0] == np.array([0, 2])).all()
+
+    lmts = clst.get_cluster_limits(0, retain_mass=0.68, ignore_space=False)
+    assert (lmts[0] == np.array([0, 2, 4])).all()
+
+    lmts = clst.get_cluster_limits(0, retain_mass=0.83, ignore_space=False)
+    assert (lmts[0] == np.array([0, 2, 4, 6])).all()
+
+
 def test_clusters():
     import mne
     import matplotlib.pyplot as plt

--- a/borsar/tests/test_cluster.py
+++ b/borsar/tests/test_cluster.py
@@ -153,6 +153,13 @@ def test_get_mass_range():
     assert _get_mass_range(contrib, 0.48) == slice(2, 6)
     assert _get_mass_range(contrib, 0.57) == slice(2, 7)
 
+    assert (_get_mass_range(contrib, 0.3, adjacent=False) ==
+            np.array([3, 4])).all()
+    assert (_get_mass_range(contrib, 0.38, adjacent=False) ==
+            np.array([0, 3, 4])).all()
+    assert (_get_mass_range(contrib, 0.53, adjacent=False) ==
+            np.array([0, 3, 4, 9])).all()
+
     # with break
     contrib = np.array([0.15, 0.15, 0., 0.15, 0.2, 0.1, 0.])
     slc = _get_mass_range(contrib, 0.5)


### PR DESCRIPTION
fixes #23

now with `ignore_space=False` `clst.get_cluster_limits(...)` returns indices for the spatial dimension.