### PR TITLE
ENH: add read_info and write_info

### DIFF
--- a/borsar/tests/test_utils.py
+++ b/borsar/tests/test_utils.py
@@ -48,7 +48,8 @@ def compare_info(info1, info2):
     pos1, pos2 = get_ch_pos(info1), get_ch_pos(info2)
     pos1 = pos1[~np.isnan(pos1).all(axis=1)]
     pos2 = pos2[~np.isnan(pos2).all(axis=1)]
-    is_empty = lambda pos: pos.shape[0] == 0
+    def is_empty(pos):
+        return pos.shape[0] == 0
     assert (is_empty(pos1) and is_empty(pos2)) or (pos1 == pos2).all()
 
 

--- a/borsar/tests/test_utils.py
+++ b/borsar/tests/test_utils.py
@@ -48,8 +48,10 @@ def compare_info(info1, info2):
     pos1, pos2 = get_ch_pos(info1), get_ch_pos(info2)
     pos1 = pos1[~np.isnan(pos1).all(axis=1)]
     pos2 = pos2[~np.isnan(pos2).all(axis=1)]
+
     def is_empty(pos):
         return pos.shape[0] == 0
+
     assert (is_empty(pos1) and is_empty(pos2)) or (pos1 == pos2).all()
 
 

--- a/borsar/tests/test_utils.py
+++ b/borsar/tests/test_utils.py
@@ -55,7 +55,8 @@ def compare_info(info1, info2):
 
 def test_read_write_info():
     data_dir = _get_test_data_dir()
-    raw = create_fake_raw(n_channels=2, n_samples=5, sfreq=25.)
+    raw = create_fake_raw(n_channels=4, n_samples=5, sfreq=25.)
+    raw.set_channel_types({'a': 'eeg', 'b': 'ecog', 'c': 'eeg', 'd': 'ecog'})
 
     fname = op.join(data_dir, 'temp_info.hdf5')
     if op.isfile(fname):

--- a/borsar/utils.py
+++ b/borsar/utils.py
@@ -139,9 +139,10 @@ def read_info(fname):
 
     # parse ch_type
     if isinstance(data_dict['ch_type'], dict):
-        ch_type = np.empty(5, dtype='S10')
-        for type, idx in data_dict['ch_type'].items():
-            ch_type[idx] = type
+        ch_type = [None] * len(ch_names)
+        for type, idxs in data_dict['ch_type'].items():
+            for idx in idxs:
+                ch_type[idx] = type
     else:
         ch_type = data_dict['ch_type']
 

--- a/borsar/utils.py
+++ b/borsar/utils.py
@@ -100,16 +100,20 @@ def write_info(fname, info, overwrite=False):
     _validate_type(fname, 'str', item_name='fname')
     _validate_type(info, 'info', item_name='info')
 
-    # extract relevant data
+    # extract type info
     tps = channel_indices_by_type(info)
-    _ = [tps.pop(k) for k in list(tps.keys()) if len(tps[k]) == 0]
+
+    # remove empty dict keys
+    for k in list(tps.keys()):
+        if len(tps[k]) == 0:
+            tps.pop(k)
+
     has_types = list(tps.keys())
     ch_type = has_types[0] if len(has_types) == 1 else tps
 
+    # save to .hdf5
     data_dict = {'ch_names': info['ch_names'], 'sfreq': info['sfreq'],
                  'ch_type': ch_type, 'pos': get_ch_pos(info)}
-
-    # save to .hdf5
     h5io.write_hdf5(fname, data_dict, overwrite=overwrite)
 
 


### PR DESCRIPTION
Ability to save only `Info` would be beneficial to saving and reading Clusters. First info could be saved to a  separate file and read using `read_info`, then `read_clusters` could get info path and throw error if it is not possible, and last `Clusters.save()` could also save info (first in a sep file then in the same hdf5).