### PR TITLE
FIX: allow to visualize cluster results done on subspace of src

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_install:
     fi
   - git clone https://github.com/astropy/ci-helpers.git
   - source ci-helpers/travis/setup_conda.sh
+  - pip install vtk
 
 install:
   # Rvm overrides cd with a function so that it can hook into it to run

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,20 @@ language: c
 dist: xenial
 sudo: required
 
+env:
+  global: PYTHON_VERSION=3.6 TRAVIS_PYTHON_VERSION=3.6 CONDA_VERSION=">=4.3.27"
+          CONDA_ENVIRONMENT="environment.yml"
+
 matrix:
   include:
     - os: linux
-      env: USE_NUMBA="yes" TRAVIS_PYTHON_VERSION=3.6
+      env: USE_NUMBA="yes"
 
     - os: linux
-      env: USE_NUMBA="no" TRAVIS_PYTHON_VERSION=3.6
+      env: USE_NUMBA="no"
 
     - os: osx
-      env: USE_NUMBA="no" TRAVIS_PYTHON_VERSION=3.6
+      env: USE_NUMBA="no"
 
 before_install:
   - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
@@ -19,9 +23,9 @@ before_install:
     else
       sudo apt-get update;
     fi
+  - curl -O https://raw.githubusercontent.com/mne-tools/mne-python/master/environment.yml
   - git clone https://github.com/astropy/ci-helpers.git
   - source ci-helpers/travis/setup_conda.sh
-  - pip install vtk
 
 install:
   # Rvm overrides cd with a function so that it can hook into it to run
@@ -34,8 +38,6 @@ install:
   - conda info -a
 
   # install dependencies
-  - curl -O https://raw.githubusercontent.com/mne-tools/mne-python/master/environment.yml
-  - conda env create -f environment.yml
   - source activate mne
   - if [ "${USE_NUMBA}" == "yes" ]; then
       conda install numba;

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,6 @@ install:
   - conda info -a
 
   # install dependencies
-  - source activate mne
   - if [ "${USE_NUMBA}" == "yes" ]; then
       conda install numba;
     fi

--- a/borsar/cluster.py
+++ b/borsar/cluster.py
@@ -1272,11 +1272,10 @@ def _clusters_chan_vert_checks(dimnames, info, src, subject, subjects_dir,
             vert_num_all = vert_num_lh + vert_num_rh
             vert_idx_in_src = (vertices < vert_num_all).all()
             if not vert_idx_in_src:
-                raise ValueError(('Some vertex indices go beyond the '
-                                  'available source space extent. Number of '
-                                  'used vertices (lh + rh) = {:d}, while '
-                                  'maximum index in the ``vertices`` = '
-                                  '{:d}.').format(vert_num_all, vertices.max()))
+                msg = ('Some vertex indices go beyond the available source '
+                       'space extent. Number of used vertices (lh + rh) = '
+                       '{:d}, while maximum index in the ``vertices`` = {:d}.')
+                raise ValueError(msg.format(vert_num_all, vertices.max()))
 
             # turn to lh, rh dictionary
             lh_mask = vertices < vert_num_lh

--- a/borsar/cluster.py
+++ b/borsar/cluster.py
@@ -1272,8 +1272,8 @@ def _clusters_chan_vert_checks(dimnames, info, src, subject, subjects_dir,
             vert_num_all = vert_num_lh + vert_num_rh
             vert_idx_in_src = (vertices < vert_num_all).all()
             if not vert_idx_in_src:
-                msg = ('Some vertex indices go beyond the available source '
-                       'space extent. Number of used vertices (lh + rh) = '
+                msg = ('Some vertex indices exceed the available source '
+                       'space size. Number of vertices in the src (lh + rh) = '
                        '{:d}, while maximum index in the ``vertices`` = {:d}.')
                 raise ValueError(msg.format(vert_num_all, vertices.max()))
 

--- a/borsar/clusterutils.py
+++ b/borsar/clusterutils.py
@@ -5,16 +5,21 @@ from borsar.stats import format_pvalue
 def _get_units(dimname, fullname=False):
     '''Return unit for specified dimension name.'''
     if not fullname:
-        return {'freq': 'Hz', 'time': 's'}[dimname]
+        return {'freq': 'Hz', 'time': 's', 'vert': 'vert'}[dimname]
     else:
-        return {'freq': 'hertz', 'time': 'seconds'}[dimname]
+        return {'freq': 'hertz', 'time': 'seconds', 'vert': 'vertices'}[dimname]
 
 
 def _check_stc(clst):
     '''Make sure Clusters has a list of mne.SourceEstimate in stc attribute.'''
     import mne
     if clst.stc is None:
-        vert = [clst.src[0]['vertno'], clst.src[1]['vertno']]
+        if clst.vertices is None:
+            vert = [clst.src[0]['vertno'], clst.src[1]['vertno']]
+        else:
+            lh, rh = [clst.vertices[hemi] for hemi in ['lh', 'rh']]
+            vert = [clst.src[0]['vertno'][lh], clst.src[1]['vertno'][rh]]
+
         assert clst.dimnames.index('vert') == 0
 
         tmin, tstep = 1., 1.

--- a/borsar/clusterutils.py
+++ b/borsar/clusterutils.py
@@ -7,7 +7,8 @@ def _get_units(dimname, fullname=False):
     if not fullname:
         return {'freq': 'Hz', 'time': 's', 'vert': 'vert'}[dimname]
     else:
-        return {'freq': 'hertz', 'time': 'seconds', 'vert': 'vertices'}[dimname]
+        return {'freq': 'hertz', 'time': 'seconds',
+                'vert': 'vertices'}[dimname]
 
 
 def _check_stc(clst):

--- a/borsar/tests/test_cluster.py
+++ b/borsar/tests/test_cluster.py
@@ -541,18 +541,26 @@ def test_clusters():
 
     # _clusters_chan_vert_checks
     with pytest.raises(TypeError, match='must pass an `mne.Info`'):
-        _clusters_chan_vert_checks(['chan', 'freq'], None, None, None, None)
+        _clusters_chan_vert_checks(['chan', 'freq'], None, None, None, None,
+                                   None)
 
     with pytest.raises(TypeError, match='must pass an `mne.SourceSpaces`'):
-        _clusters_chan_vert_checks(['vert', 'freq'], None, None, None, None)
+        _clusters_chan_vert_checks(['vert', 'freq'], None, None, None, None,
+                                   None)
 
     with pytest.raises(TypeError, match='must pass a subject string'):
         _clusters_chan_vert_checks(['vert', 'freq'], None, fwd['src'],
-                                   None, None)
+                                   None, None, None)
 
     with pytest.raises(TypeError, match='must pass a `subjects_dir`'):
         _clusters_chan_vert_checks(['vert', 'freq'], None, fwd['src'],
-                                   'fsaverage', None)
+                                   'fsaverage', None, None)
+
+    n_vert = len(fwd['src'][0]['vertno']) + len(fwd['src'][1]['vertno'])
+    vertices = np.arange(n_vert + 1)
+    with pytest.raises(ValueError, match='vertex indices go beyond'):
+        _clusters_chan_vert_checks(['vert', 'freq'], None, fwd['src'],
+                                   'fsaverage', data_dir, vertices)
 
     with pytest.raises(TypeError, match='context'):
         _check_dimnames_kwargs(clst2, allow_lists=False, freq=[8, 9, 10])


### PR DESCRIPTION
Having a cluster results from a subspace of src breaks plotting, now `vertices` can be used to inform which vertices (out of used src vertices) were used in clustering.