### PR TITLE
DEV: make osx travis faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,6 @@ matrix:
       env: USE_NUMBA="no"
 
 before_install:
-  - if [ "${TRAVIS_OS_NAME}" == "osx" ]; then
-      brew update;
-    else
-      sudo apt-get update;
-    fi
   - curl -O https://raw.githubusercontent.com/mmagnuski/borsar/master/environment.yml
   - git clone https://github.com/astropy/ci-helpers.git
   - source ci-helpers/travis/setup_conda.sh

--- a/borsar/tests/test_cluster.py
+++ b/borsar/tests/test_cluster.py
@@ -207,8 +207,10 @@ def test_cluster_based_regression():
 
 
 def test_cluster_based_regression_3d_simulated():
-    # ground truth - cluster locations
+    np.random.seed(23)
     T, F = True, False
+
+    # ground truth - cluster locations
     data = np.random.normal(size=(10, 3, 5, 5))
     adjacency = np.array([[F, T, T], [T, F, T], [T, T, F]])
     pos_clst = [[0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2],
@@ -241,7 +243,7 @@ def test_cluster_based_regression_3d_simulated():
     stat = stat.swapaxes(0, -1)
     clst = [c.swapaxes(0, -1) for c in clst]
 
-    # find pos and neg clusters
+    # find index of positive and negative clusters
     clst_stat = np.array([stat[c].sum() for c in clst])
     pos_clst_idx = (pvals[clst_stat > 0].argmin() +
                     np.where(clst_stat > 0)[0][0])
@@ -250,9 +252,9 @@ def test_cluster_based_regression_3d_simulated():
 
     # assert that clusters are similar to locations of original effects
     assert clst[pos_clst_idx][pos_idx[1:]].mean() > 0.75
-    assert clst[pos_clst_idx][neg_idx[1:]].mean() < 0.1
-    assert clst[neg_clst_idx][neg_idx[1:]].mean() > 0.5
-    assert clst[neg_clst_idx][pos_idx[1:]].mean() < 0.1
+    assert clst[pos_clst_idx][neg_idx[1:]].mean() < 0.29
+    assert clst[neg_clst_idx][neg_idx[1:]].mean() > 0.75
+    assert clst[neg_clst_idx][pos_idx[1:]].mean() < 0.29
 
 
 def test_get_mass_range():


### PR DESCRIPTION
Travis osx is now faster by about 4 minutes given that setup + tests take only 5 minutes on linux - this is considerable improvement).
I will leave it open to fix other test-related stuff:
- [x] better cluster-level tests (set rng state or create better test for the one that fails often - with random simulated data)