### PR TITLE
Cluster viz 0.2

### DIFF
--- a/borsar/_viz3d.py
+++ b/borsar/_viz3d.py
@@ -54,8 +54,7 @@ def plot_cluster_src(clst, cluster_idx=None, aggregate='mean', set_light=True,
     # get and aggregate cluster mask and cluster stat
     # TODO - first idx then aggregation
     clst_mask, clst_stat, idx = _aggregate_cluster(
-        clst, cluster_idx, mask_proportion=0.5, retain_mass=0.65,
-        ignore_space=True, **kwargs)
+        clst, cluster_idx, mask_proportion=0.5, retain_mass=0.65, **kwargs)
 
     # create label from cluster
     clst_label = _label_from_cluster(clst, clst_mask.astype('float'))

--- a/borsar/cluster.py
+++ b/borsar/cluster.py
@@ -5,7 +5,8 @@ from borsar.utils import find_index, find_range, has_numba
 from borsar.stats import compute_regression_t
 from borsar._viz3d import plot_cluster_src
 from borsar.clusterutils import (_get_clim, _aggregate_cluster, _get_units,
-                                 _handle_dims, _get_dimcoords, _label_axis)
+                                 _handle_dims, _get_dimcoords, _label_axis,
+                                 _mark_cluster_range)
 from borsar.channels import find_channels
 
 
@@ -1287,9 +1288,13 @@ def plot_cluster_chan(clst, cluster_idx=None, dims=None, aggregate='mean',
 
             # FIXME - work in progress
             # show a line plot of the effect
-            # plt.plot(clst_stat)
-            raise NotImplementedError
-            # add highligh (will have to wait for moving highligh from sarna)
+            import matplotlib.pyplot as plt
+            x_axis = _get_dimcoords(clst, dim_idx[0], idx[dim_idx[0]])
+            fig, ax = plt.subplots()
+            ax.plot(x_axis, clst_stat)
+            _label_axis(ax, clst, dim_idx[0], ax_dim='x')
+            _mark_cluster_range(clst_mask, x_axis, ax)
+            return ax
     elif len(dim_idx) == 2:
         # heatmap
         # -------

--- a/borsar/cluster.py
+++ b/borsar/cluster.py
@@ -1183,7 +1183,8 @@ def plot_cluster_chan(clst, cluster_idx=None, dims=None, aggregate='mean',
     vmax : float, optional
         Value mapped to maximum in the colormap. Inferred from data by default.
     mark_kwargs : dict | None, optional
-        Keyword arguments for ``Topo.mark_channels``. For example:
+        Keyword arguments for ``Topo.mark_channels`` used to mark channels
+        participating in selected cluster. For example:
         ``mark_kwargs={'markersize': 3}`` to change the size of the markers.
         ``None`` defaults to ``{'markersize: 5'}``.
     **kwargs : additional arguments
@@ -1300,9 +1301,18 @@ def plot_cluster_chan(clst, cluster_idx=None, dims=None, aggregate='mean',
 
         if clst_mask is None:
             outlines = False
+
+        # CHECK - cluster reduction seems not to be necessary as it is done
+        #         cluster aggregation
         # else:
         #     if clst_mask.ndim > len(dim_idx):
         #         clst_mask = clst_mask.any(axis=(ix + 1 for ix i))
+
+        # make sure the dimension order is correct
+        if not (np.sort(dim_idx) == dim_idx).all():
+            clst_stat = clst_stat.T
+            if clst_mask is not None:
+                clst_mask = clst_mask.T
 
         # get dimension coords
         x_axis = _get_dimcoords(clst, dim_idx[1], idx[dim_idx[1]])

--- a/borsar/cluster.py
+++ b/borsar/cluster.py
@@ -4,7 +4,8 @@ from scipy import sparse
 from borsar.utils import find_index, find_range, has_numba
 from borsar.stats import compute_regression_t
 from borsar._viz3d import plot_cluster_src
-from borsar.clusterutils import (_get_clim, _aggregate_cluster, _get_units)
+from borsar.clusterutils import (_get_clim, _aggregate_cluster, _get_units,
+                                 _handle_dims)
 from borsar.channels import find_channels
 
 
@@ -500,6 +501,9 @@ def read_cluster(fname, subjects_dir=None, src=None, info=None):
 # TODO - consider empty lists/arrays instead of None when no clusters...
 #      - [ ] add repr so that Cluster has nice text representation
 #      - [ ] add reading and writing to FieldTrip cluster structs
+#      - [ ] change order to stat, clusters, pvals
+#      - [ ] make stat, clusters and pvals keyword
+#      - [ ] make only stat necessary
 class Clusters(object):
     '''
     Container for results of cluster-based tests.

--- a/borsar/cluster.py
+++ b/borsar/cluster.py
@@ -1590,11 +1590,6 @@ def _check_dimnames_kwargs(clst, check_dimcoords=False, ignore_dims=None,
                    'dimensions: {}.'.format(dim, ', '.join(clst.dimnames)))
             raise ValueError(msg)
 
-        if ignore_dims is not None and dim in ignore_dims:
-            msg = ("Dimension {} is both in `ignore_dims` and is used as"
-                   "keyword argument.")
-            raise ValueError(msg.format(dim))
-
         if not allow_lists and isinstance(kwargs[dim], (list, np.ndarray)):
             msg = ('Use of lists/numpy arrays of datapoints are not supported'
                    ' in this context. Use range ((min, max) tuple) or mass/'

--- a/borsar/clusterutils.py
+++ b/borsar/clusterutils.py
@@ -55,11 +55,27 @@ def _get_clim(data, vmin=None, vmax=None, pysurfer=False):
         return vmin, vmax
 
 
+def _handle_dims(clst, dims):
+    '''Find indices of dimension names.'''
+    if dims is None:
+        if clst.dimnames[0] in ['chan', 'vert']:
+            return 0
+        else:
+            raise ValueError("Can't infer the dimensions to plot when the"
+                             " first dimension is not 'chan' or 'vert'."
+                             " Please use ``dims`` argument.")
+    else:
+        if isinstance(dims, str):
+            dims = [dims]
+        dim_idx = [clst.dimnames.index(dim) for dim in dims]
+        return dim_idx
+
+
 # TODO:
 # - [ ] _aggregate_cluster aggregates by default everything except the spatial
 #       dimension. This would be problematic for spaces like [freq, time]
-#       consider adding ``along`` or ``dim`` argument. Then ``ignore_space``
-#       could be removed.
+#       consider adding ``dim`` argument. Then ``ignore_space`` could be
+#       removed.
 # - [ ] beware of changing dimension order for some complex "facny index"
 #       operations
 def _aggregate_cluster(clst, cluster_idx, mask_proportion=0.5,

--- a/borsar/tests/test_cluster.py
+++ b/borsar/tests/test_cluster.py
@@ -4,6 +4,7 @@ import warnings
 
 import pytest
 import numpy as np
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 
 from scipy import sparse
@@ -919,6 +920,13 @@ def test_cluster_ignore_dims():
     assert axs[0].get_xlabel() == 'Frequency (Hz)'
     assert axs[0].get_ylabel() == 'Time (s)'
 
+    # test empty clusters -> no outlines
+    clst2 = clst.copy()
+    clst2.clusters = clst2.clusters.copy()
+    clst2.clusters[0] = False
+    axs = clst.plot(cluster_idx=0, dims=['time', 'freq'])
+    # FIXME - check that there is no outlines now / no cluster mask
+
     # _get_dimcoords
     coords = _get_dimcoords(clst, 1)
     assert (coords == clst.dimcoords[1]).all()
@@ -940,6 +948,17 @@ def test_cluster_ignore_dims():
 
     _label_axis(ax, clst, 0, 'y')
     assert ax.get_ylabel() == 'Channels'
+
+    # no more than 2 dims:
+    with pytest.raises(ValueError, match='more than two'):
+        clst.plot(cluster_idx=0, dims=['chan', 'freq', 'time'])
+
+    # line plot
+    # ---------
+    ax = clst.plot(dims='time')
+    chld = ax.get_children()
+    assert isinstance(chld[0], mpl.patches.Rectangle)
+    assert np.any([isinstance(ch, mpl.lines.Line2D) for ch in chld])
 
 
 @pytest.mark.skip(reason="mayavi kills CI tests")

--- a/borsar/tests/test_cluster.py
+++ b/borsar/tests/test_cluster.py
@@ -856,15 +856,29 @@ def test_cluster_ignore_dims():
     assert clst_mask is None
     assert (clst_stat == data.mean(axis=(1, 2))).all()
 
-    clst_mask, clst_stat, _ = _aggregate_cluster(
+    clst_mask, clst_stat1, _ = _aggregate_cluster(
         clst, [None], ignore_dims=['freq', 'time'])
     assert clst_mask is None
-    assert (clst_stat == data.mean(axis=0)).all()
+    assert (clst_stat1 == data.mean(axis=0)).all()
 
     clst_mask, clst_stat, _ = _aggregate_cluster(
         clst, [None], ignore_dims=['freq'])
     assert clst_mask is None
     assert (clst_stat == data.mean(axis=(0, 2))).all()
+
+    # test heatmap
+    # ------------
+    axs = clst.plot(cluster_idx=0, dims=['freq', 'time'])
+    # make sure image data is correct
+    data = np.array(axs[0].images[0].get_array())
+    assert (clst.stat.mean(axis=0) == data).all()
+
+    # make sure axes are annotated correctly
+    ylab = axs[0].get_ylabel()
+    assert ylab == 'Frequency (Hz)'
+
+    xlab = axs[0].get_xlabel()
+    assert xlab == 'Time (s)'
 
 
 @pytest.mark.skip(reason="mayavi kills CI tests")

--- a/borsar/tests/test_cluster.py
+++ b/borsar/tests/test_cluster.py
@@ -4,6 +4,8 @@ import warnings
 
 import pytest
 import numpy as np
+import matplotlib.pyplot as plt
+
 from scipy import sparse
 from scipy.io import loadmat
 from skimage.filters import gaussian
@@ -831,8 +833,9 @@ def test_cluster_ignore_dims():
     # _handle_dims can only take None as the second arg if the first dim
     # in the CLusters is spatial
     clst2 = clst.copy()
+    clst2.dimnames = clst2.dimnames.copy()
     clst2.dimnames[0] = 'cheese'
-    with pytest.raises(ValueError, match="Can't infer dimensions to plot"):
+    with pytest.raises(ValueError, match="Can't infer the dimensions to plot"):
         _handle_dims(clst2, None)
 
     # check aggregation with ignored dims passed

--- a/borsar/tests/test_cluster.py
+++ b/borsar/tests/test_cluster.py
@@ -322,13 +322,13 @@ def test_cluster_limits():
     clst = Clusters([clusters], pvals, stat, dimnames=['chan', 'freq'],
                     dimcoords=dimcoords, info=info)
 
-    lmts = clst.get_cluster_limits(0, retain_mass=0.66, ignore_space=False)
+    lmts = clst.get_cluster_limits(0, retain_mass=0.66, dims=['chan', 'freq'])
     assert (lmts[0] == np.array([0, 2])).all()
 
-    lmts = clst.get_cluster_limits(0, retain_mass=0.68, ignore_space=False)
+    lmts = clst.get_cluster_limits(0, retain_mass=0.68, dims=['chan', 'freq'])
     assert (lmts[0] == np.array([0, 2, 4])).all()
 
-    lmts = clst.get_cluster_limits(0, retain_mass=0.83, ignore_space=False)
+    lmts = clst.get_cluster_limits(0, retain_mass=0.83, dims=['chan', 'freq'])
     assert (lmts[0] == np.array([0, 2, 4, 6])).all()
 
 

--- a/borsar/tests/test_utils.py
+++ b/borsar/tests/test_utils.py
@@ -11,7 +11,8 @@ from borsar.channels import get_ch_pos
 from borsar.utils import (create_fake_raw, _check_tmin_tmax, detect_overlap,
                           get_info, valid_windows, get_dropped_epochs,
                           find_range, find_index, silent_mne, read_info,
-                          write_info, _get_test_data_dir, has_numba)
+                          write_info, _get_test_data_dir, has_numba,
+                          group_mask)
 
 
 def almost_equal(val1, val2, error=1e-13):
@@ -201,3 +202,25 @@ def test_silent_mne():
             warn('annoying warning!', DeprecationWarning)
 
     assert len(record) == 0
+
+
+def test_group():
+    msk = np.array([False, False, False, False, True, True, True, True, True,
+                    False, False, False, False, False, False, False, False,
+                    False, False, False, False, False, False, False, False,
+                    False, False])
+    grp = group_mask(msk)
+    assert (grp == np.array([[4, 8]])).all()
+
+    msk[:2] = True
+    grp = group_mask(msk)
+    assert (grp == np.array([[0, 1], [4, 8]])).all()
+
+    msk[-3:] = True
+    grp = group_mask(msk)
+    assert (grp == np.array([[0, 1], [4, 8], [24, 26]])).all()
+
+
+    msk[12:19] = True
+    grp = group_mask(msk)
+    assert (grp == np.array([[0, 1], [4, 8], [12, 18], [24, 26]])).all()

--- a/borsar/tests/test_utils.py
+++ b/borsar/tests/test_utils.py
@@ -220,7 +220,6 @@ def test_group():
     grp = group_mask(msk)
     assert (grp == np.array([[0, 1], [4, 8], [24, 26]])).all()
 
-
     msk[12:19] = True
     grp = group_mask(msk)
     assert (grp == np.array([[0, 1], [4, 8], [12, 18], [24, 26]])).all()

--- a/borsar/utils.py
+++ b/borsar/utils.py
@@ -151,8 +151,12 @@ def read_info(fname):
     mntg = None
     pos = data_dict['pos']
     if pos is not None and not np.isnan(pos).all():
-        mntg = mne.channels.Montage(pos, ch_names, 'unknown',
-                                    np.arange(pos.shape[0]))
+        try:
+            mntg = mne.channels.Montage(pos, ch_names, 'unknown',
+                                        np.arange(pos.shape[0]))
+        except AttributeError:
+            ch_pos = {chnm: chpos for chnm, chpos in zip(ch_names, pos)}
+            mntg = mne.channels.make_dig_montage(ch_pos=ch_pos)
 
     # create info
     info = mne.create_info(ch_names, data_dict['sfreq'],

--- a/borsar/utils.py
+++ b/borsar/utils.py
@@ -72,6 +72,30 @@ def find_index(vec, vals):
         return np.array(outlist)
 
 
+def group_mask(mask):
+    '''Groups a 1D boolean mask into array of starts and stops of ``True``
+    value ranges.
+
+    Parameters
+    ----------
+    mask : 1D boolean array
+        Boolean array to group.
+
+    Returns
+    -------
+    groups : 2D int array
+        Array of True ranges starts (first column) and stops (last column).
+        Each row represents one range of True values.
+    '''
+    changes = np.where(np.diff(mask))[0]
+    frnt = [-1] if mask[0] else np.array([], dtype='int')
+    bck = [mask.shape[0] - 1] if mask[-1] else np.array([], dtype='int')
+    groups = np.concatenate([frnt, changes, bck])
+    groups = groups.reshape((-1, 2))
+    groups[:, 0] += 1
+    return groups
+
+
 def get_info(inst):
     '''Simple helper function that returns Info whatever mne object it gets.'''
 


### PR DESCRIPTION
The goal of this PR is to allow to visualize clusters in other ways than just topographies.
For example `clst.plot(dims='time')` should allow to see effects in time as a line while `clst.plot(dims=['freq', 'time'])` would allow to show a time-frequency heatmap of effects.

`clst.plot(dims='freq', freq=(2, 10))` should both select given frequency range but not average. 
`clst.plot(dims='freq', freq=[2, 5, 8])` seems problematic - it would be best if it raised an error (surprisingly it seems to work well, so I'm leaving that as it is).

## TODOs:
- [x] add `ignore_dims`
- [x] resolve the usage of `ignore_space` and `ignore_dims` in cluster aggregation
- [x] show heatmap when 2 dims
- [x] add lineplot option for single non-spatial dimension
- [x] resolve the usage of `ignore_space` and `ignore_dims` in other functions
- [x] add remaining tests

### future:
* create an example using Olga results to showcase cluster plotting
* consider adding a topo inset when spatial dimension is averaged (subsequent PRs)
* `clst.plot(dims=['chan', 'time'], kind='line')` to see something similar to Evoked plot but of the effects