### PR TITLE
Extrapolation edges

### DIFF
--- a/borsar/_mne_modified.py
+++ b/borsar/_mne_modified.py
@@ -1,20 +1,23 @@
 import warnings
 import numpy as np
+from numbers import Integral
+
 from mne import Info
 from mne.io.pick import _pick_data_channels, pick_info, channel_type
 from mne.defaults import _handle_default
 from mne.viz.utils import plt_show, _setup_vmin_vmax
 from mne.viz.topomap import (_check_outlines, _prepare_topomap, _autoshrink,
                              _plot_sensors, _draw_outlines, _GridData,
-                             _find_topomap_coords)
+                             _find_topomap_coords, _get_extra_points)
 
 
 def plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
                  res=64, axes=None, names=None, show_names=False, mask=None,
                  mask_params=None, outlines='head',
                  contours=6, image_interp='bilinear', show=True,
-                 head_pos=None, onselect=None, extrapolate='box'):
+                 head_pos=None, onselect=None, extrapolate='box', border=0):
     """Plot a topographic map as image.
+
     Parameters
     ----------
     data : array, shape (n_chan,)
@@ -100,6 +103,10 @@ def plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
         points (approximately to points closer than median inter-electrode
         distance).
         .. versionadded:: 0.18
+    border : float | 'mean'
+        Value to extrapolate to on the topomap borders. If ``'mean'`` then
+        each extrapolated point has the average value of its neighbours.
+
     Returns
     -------
     im : matplotlib.image.AxesImage
@@ -110,14 +117,14 @@ def plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
     return _plot_topomap(data, pos, vmin, vmax, cmap, sensors, res, axes,
                          names, show_names, mask, mask_params, outlines,
                          contours, image_interp, show,
-                         head_pos, onselect, extrapolate)
+                         head_pos, onselect, extrapolate, border)
 
 
 def _plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
                   res=64, axes=None, names=None, show_names=False, mask=None,
                   mask_params=None, outlines='head',
                   contours=6, image_interp='bilinear', show=True,
-                  head_pos=None, onselect=None, extrapolate='box'):
+                  head_pos=None, onselect=None, extrapolate='box', border=0):
     import matplotlib.pyplot as plt
     from matplotlib.widgets import RectangleSelector
     data = np.asarray(data)
@@ -213,7 +220,7 @@ def _plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
     xi = np.linspace(xmin, xmax, res)
     yi = np.linspace(ymin, ymax, res)
     Xi, Yi = np.meshgrid(xi, yi)
-    interp = _GridData(pos, extrapolate, head_radius).set_values(data)
+    interp = _GridData(pos, extrapolate, head_radius, border).set_values(data)
     Zi = interp.set_locations(Xi, Yi)()
 
     # plot outline
@@ -309,12 +316,13 @@ class _GridData(object):
     to be set independently.
     """
 
-    def __init__(self, pos, method='box', head_radius=None):
+    def __init__(self, pos, method='box', head_radius=None, border=0):
         # in principle this works in N dimensions, not just 2
         assert pos.ndim == 2 and pos.shape[1] == 2
         # Adding points outside the extremes helps the interpolators
         outer_pts, tri = _get_extra_points(pos, method, head_radius)
         self.n_extra = outer_pts.shape[0]
+        self.border = border
         self.tri = tri
 
     def set_values(self, v):
@@ -327,7 +335,20 @@ class _GridData(object):
         # Eventually we could also do set_values with this class if we want,
         # see scipy/interpolate/rbf.py, especially the self.nodes one-liner.
         from scipy.interpolate import CloughTocher2DInterpolator
-        v = np.concatenate((v, np.zeros(self.n_extra)))
+
+        if isinstance(self.border, Integral):
+            v_extra = np.ones(self.n_extra) * self.border
+        elif isinstance(self.border, str) and self.border == 'mean':
+            n_points = v.shape[0]
+            v_extra = np.zeros(self.n_extra)
+            indices, indptr = self.tri.vertex_neighbor_vertices
+            rng = range(n_points, n_points + self.n_extra)
+            for idx, extra_idx in enumerate(rng):
+                ngb = indptr[indices[extra_idx]:indices[extra_idx + 1]]
+                ngb = ngb[ngb < n_points]
+                v_extra[idx] = v[ngb].mean()
+
+        v = np.concatenate((v, v_extra))
         self.interpolator = CloughTocher2DInterpolator(self.tri, v)
         return self
 

--- a/borsar/_mne_modified.py
+++ b/borsar/_mne_modified.py
@@ -7,8 +7,8 @@ from mne.io.pick import _pick_data_channels, pick_info, channel_type
 from mne.defaults import _handle_default
 from mne.viz.utils import plt_show, _setup_vmin_vmax
 from mne.viz.topomap import (_check_outlines, _prepare_topomap, _autoshrink,
-                             _plot_sensors, _draw_outlines, _GridData,
-                             _find_topomap_coords, _get_extra_points)
+                             _plot_sensors, _draw_outlines, _get_extra_points,
+                             _find_topomap_coords)
 
 
 def plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,

--- a/borsar/tests/test_viz.py
+++ b/borsar/tests/test_viz.py
@@ -62,6 +62,12 @@ def test_topo():
     # test topo update
     topo = Topo(alpha_topo, raw.info, show=False)
     topo.update(alpha_topo[::-1])
+    
+    # make sure border='mean' works
+    topo = Topo(alpha_topo, raw.info, outlines='skirt', extrapolate='head',
+                border='mean', show=False)
+    assert topo.interpolator.border == 'mean'
+    # add a test for one point checking if its value is the mean of neighbours
 
 
 def test_multi_topo():

--- a/borsar/tests/test_viz.py
+++ b/borsar/tests/test_viz.py
@@ -62,7 +62,7 @@ def test_topo():
     # test topo update
     topo = Topo(alpha_topo, raw.info, show=False)
     topo.update(alpha_topo[::-1])
-    
+
     # make sure border='mean' works
     topo = Topo(alpha_topo, raw.info, outlines='skirt', extrapolate='head',
                 border='mean', show=False)


### PR DESCRIPTION
Adds `border='mean'` option for extrapolating to mean of neighbours, not zero.

![image](https://user-images.githubusercontent.com/8452354/72008749-d3c89100-3254-11ea-9aca-e2776b416806.png)
