### PR TITLE
Cluster colors

### DIFF
--- a/borsar/_heatmap.py
+++ b/borsar/_heatmap.py
@@ -100,8 +100,8 @@ def heatmap(array, mask=None, axis=None, x_axis=None, y_axis=None,
     ext = [*(x_axis[[0, -1]] + [-x_step / 2, x_step / 2]),
            *(y_axis[[0, -1]] + [-y_step / 2, y_step / 2])]
 
-
-    mask_ = mask.any(axis=0) if mask.ndim == 3 else mask
+    mask_is_3d = isinstance(mask, np.ndarray) and mask.ndim == 3
+    mask_ = mask.any(axis=0) if mask_is_3d else mask
     out = _masked_image(array, mask=mask_, vmin=vmin, vmax=vmax,
                         cmap=cmap, aspect='auto', extent=ext,
                         interpolation='nearest', origin='lower',
@@ -128,8 +128,8 @@ def heatmap(array, mask=None, axis=None, x_axis=None, y_axis=None,
                 img.axes.plot(x_line, y_line, **this_line_kwargs)
 
     if colorbar:
-        cbar = add_colorbar_to_axis(img.axes, img)
-        # cbar.set_label('t values')
+        cbar = add_colorbar_to_axis(img.axes, img, side='right', size='5%',
+                                    pad=0.15)
         return img.axes, cbar
     else:
         return img.axes

--- a/borsar/_heatmap.py
+++ b/borsar/_heatmap.py
@@ -48,7 +48,7 @@ def _add_image_mask(mask, alpha=0.75, mask_color=(0.5, 0.5, 0.5),
 # - [ ] multiple masks, multiple outline_colors, multiple alpha?
 def heatmap(array, mask=None, axis=None, x_axis=None, y_axis=None,
             outlines=False, colorbar=True, cmap='RdBu_r', alpha=0.75,
-            vmin=None, vmax=None, line_kwargs=dict(), **kwargs):
+            vmin=None, vmax=None, line_kwargs=None, **kwargs):
     '''Plot heatmap with defaults meaningful for big heatmaps like
     time-frequency representations.
 
@@ -111,12 +111,14 @@ def heatmap(array, mask=None, axis=None, x_axis=None, y_axis=None,
 
     # add outlines if necessary
     if outlines:
-        if 'color' not in line_kwargs.keys():
-            line_kwargs['color'] = 'w'
-
         mask = mask[np.newaxis, :] if mask.ndim == 2 else mask
         n_masks = mask.shape[0]
 
+        # handle line_kwargs
+        if line_kwargs is None:
+            line_kwargs = dict()
+        if 'color' not in line_kwargs.keys():
+            line_kwargs['color'] = 'w'
         if not isinstance(line_kwargs['color'], list):
             line_kwargs['color'] = [line_kwargs['color']] * n_masks
 

--- a/borsar/_mne_020_modified.py
+++ b/borsar/_mne_020_modified.py
@@ -1,5 +1,3 @@
-import numpy as np
-
 import mne
 from mne.utils import fill_doc, _check_sphere
 from mne.viz.topomap import _plot_topomap
@@ -108,6 +106,5 @@ def plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
         head_pos = None
         return _plot_topomap(data, pos, vmin, vmax, cmap, sensors, res, axes,
                              names, show_names, mask, mask_params, outlines,
-                             contours, image_interp, show,
-                             head_pos, onselect, extrapolate,
-                             sphere=sphere, border=border)
+                             contours, image_interp, show, head_pos, onselect,
+                             extrapolate, sphere=sphere, border=border)

--- a/borsar/_mne_modified.py
+++ b/borsar/_mne_modified.py
@@ -1,7 +1,3 @@
-import warnings
-import numpy as np
-from numbers import Integral
-
 # check mne version number
 import mne
 from packaging import version

--- a/borsar/cluster/tests/test_cluster.py
+++ b/borsar/cluster/tests/test_cluster.py
@@ -577,7 +577,7 @@ def test_clusters():
     correct_idx = clst2.get_index(cluster_idx=0, freq=(8, 10),
                                   ignore_dims='vert')
     correct_mask = (clst2.clusters[[0, 1]][(slice(None),) + idx].mean(
-                    axis=-1) >= 0.5).any(axis=0)
+                    axis=-1) >= 0.5)
     assert (idx == correct_idx)
     assert (stat == clst2.stat[idx].mean(axis=-1)).all()
     assert (mask == correct_mask).all()

--- a/borsar/cluster/tests/test_cluster.py
+++ b/borsar/cluster/tests/test_cluster.py
@@ -846,8 +846,8 @@ def test_chan_freq_clusters():
     data_dict = h5io.read_hdf5(fname)
 
     try:
-        info = create_info(data_dict['dimcoords'][0], sfreq=250., ch_types='eeg',
-                           montage='easycap-M1')
+        info = create_info(data_dict['dimcoords'][0], sfreq=250.,
+                           ch_types='eeg', montage='easycap-M1')
     except TypeError:
         info = create_info(data_dict['dimcoords'][0], sfreq=250.,
                            ch_types='eeg')

--- a/borsar/cluster/tests/test_cluster.py
+++ b/borsar/cluster/tests/test_cluster.py
@@ -957,6 +957,16 @@ def test_cluster_ignore_dims():
     assert clst_mask is None
     assert (clst_stat == data.mean(axis=(0, 2))).all()
 
+    # make sure two lists or two arrays work
+    clst_mask, clst_stat, _ = _aggregate_cluster(
+        clst, 0, ignore_dims=['chan'], freq=[8, 9, 10, 11],
+        time=[0.15, 0.17, 0.19])
+
+    freq_idx = np.array([3, 4, 5, 6])[np.newaxis, :, np.newaxis]
+    time_idx = np.array([17, 18, 19])[np.newaxis, np.newaxis, :]
+    assert (clst_mask == clusters[0][:, freq_idx, time_idx]).all()
+    assert (clst_stat == data[:, freq_idx, time_idx]).all()
+
     # test heatmap
     # ------------
     clst.clusters[0] = np.zeros(clst.stat.shape, dtype='bool')
@@ -1031,6 +1041,15 @@ def test_cluster_ignore_dims():
                   if isinstance(ch, mpl.patches.Rectangle)]
     assert len(rectangles) > 1
     assert np.any([isinstance(ch, mpl.lines.Line2D) for ch in chld])
+
+
+def test_multi_cluster_plots():
+    clst = _create_random_clusters(dims='ch_fr_tm', n_clusters=3)
+    clst.plot(cluster_idx=[0, 1], dims=['chan', 'time'], freq=(8, 11))
+    clst.plot(cluster_idx=[0, 1], dims=['chan', 'time'], freq=(8, 11),
+              cluster_colors=['red', 'seagreen'])
+    clst.plot(cluster_idx=[0, 1], time=(0.15, 0.25), freq=[8, 9, 10])
+    plt.close('all')
 
 
 @pytest.mark.skip(reason="mayavi kills CI tests")

--- a/borsar/cluster/utils.py
+++ b/borsar/cluster/utils.py
@@ -332,12 +332,6 @@ def _aggregate_cluster(clst, cluster_idx, ignore_dims=None,
         clst_mask = (clst.clusters[cluster_idx] if cluster_idx[0] is not None
                      else None)
 
-    # aggregate masks if more clusters
-    # CONSIDER - this could be made optional later,
-    # especially with cluster colors
-    if clst_mask is not None:
-        clst_mask = clst_mask.any(axis=0)
-
     return clst_mask, clst_stat, idx
 
 

--- a/borsar/cluster/utils.py
+++ b/borsar/cluster/utils.py
@@ -288,13 +288,12 @@ def _aggregate_cluster(clst, cluster_idx, ignore_dims=None,
                              '{}'.format(', '.join(non_exhausted)))
 
     # find indexing
-    # FIXME - what if more clusters?
-    # FIXME - get_index should deal with arrays better
     idx = clst.get_index(cluster_idx=cluster_idx[0], ignore_dims=ignore_dims,
                          retain_mass=retain_mass, **kwargs)
     sequences = [x for x in range(len(idx))
                  if isinstance(idx[x], (list, np.ndarray))]
     if len(sequences) > 1:
+        # FIXME - separate function
         # we have to use np.ix_ to turn multiple lists/arrays to
         # indexers acceptable by numpy (.oix would be helpful here...)
         seq = [[0]] * len(idx)

--- a/borsar/cluster/utils.py
+++ b/borsar/cluster/utils.py
@@ -318,7 +318,7 @@ def _aggregate_cluster(clst, cluster_idx, ignore_dims=None,
         clst_mask = (clst.clusters[cluster_idx] if cluster_idx[0] is not None
                      else None)
 
-    if len(cluster_idx) == 1 and not clst_mask is None:
+    if len(cluster_idx) == 1 and clst_mask is not None:
         clst_mask = clst_mask[0]
 
     return clst_mask, clst_stat, idx

--- a/borsar/cluster/utils.py
+++ b/borsar/cluster/utils.py
@@ -332,6 +332,9 @@ def _aggregate_cluster(clst, cluster_idx, ignore_dims=None,
         clst_mask = (clst.clusters[cluster_idx] if cluster_idx[0] is not None
                      else None)
 
+    if len(cluster_idx) == 1 and not clst_mask is None:
+        clst_mask = clst_mask[0]
+
     return clst_mask, clst_stat, idx
 
 

--- a/borsar/cluster/utils.py
+++ b/borsar/cluster/utils.py
@@ -290,21 +290,7 @@ def _aggregate_cluster(clst, cluster_idx, ignore_dims=None,
     # find indexing
     idx = clst.get_index(cluster_idx=cluster_idx[0], ignore_dims=ignore_dims,
                          retain_mass=retain_mass, **kwargs)
-    sequences = [x for x in range(len(idx))
-                 if isinstance(idx[x], (list, np.ndarray))]
-    if len(sequences) > 1:
-        # FIXME - separate function
-        # we have to use np.ix_ to turn multiple lists/arrays to
-        # indexers acceptable by numpy (.oix would be helpful here...)
-        seq = [[0]] * len(idx)
-        for s_idx in sequences:
-            seq[s_idx] = idx[s_idx]
-
-        seq = np.ix_(*seq)
-        idx = list(idx)
-        for s_idx in sequences:
-            idx[s_idx] = seq[s_idx]
-        idx = tuple(idx)
+    idx = _clean_up_indices(idx)
 
     if do_aggregation:
         reduce_axes = tuple(ix for ix in range(0, clst.stat.ndim)
@@ -542,3 +528,33 @@ def _index_from_dim(dimnames, dimcoords, **kwargs):
             raise TypeError('Keyword arguments has to have tuple of length 2 '
                             'or a list, got {}.'.format(type(sel_ax)))
     return tuple(idx)
+
+
+def _clean_up_indices(idx):
+    '''Turn multiple fancy indexers into what is needed with ``np._ix`` and
+    extract indices from lenth one indexers.'''
+    n_indices = len(idx)
+    sequences = list()
+    for ix in range(n_indices):
+        if isinstance(idx[ix], (list, np.ndarray)):
+            sequences.append(ix)
+
+    if len(sequences) > 1:
+        idx = list(idx)
+
+    if len(sequences) > 1:
+        # we have to use np.ix_ to turn multiple lists/arrays to
+        # indexers acceptable by numpy (.oix would be helpful here...)
+        seq = [[0]] * n_indices
+        for s_idx in sequences:
+            seq[s_idx] = idx[s_idx]
+
+        seq = np.ix_(*seq)
+
+        for s_idx in sequences:
+            idx[s_idx] = seq[s_idx]
+
+    if len(sequences) > 1:
+        idx = tuple(idx)
+
+    return idx

--- a/borsar/cluster/viz.py
+++ b/borsar/cluster/viz.py
@@ -159,12 +159,13 @@ def plot_cluster_chan(clst, cluster_idx=None, dims=None, vmin=None, vmax=None,
                            pysurfer=False)
 
     # remove singleton dimensions from clst_mask
-    singletons = np.where(np.array(clst_mask.shape) == 1)[0]
-    if len(singletons) > 0:
-        clst_mask = np.squeeze(clst_mask, axis=tuple(singletons))
-    if (cluster_colors is None and isinstance(cluster_idx, list)
-        and len(cluster_idx) > 1 and clst_mask is not None):
-        clst_mask = clst_mask.any(axis=0)
+    if clst_mask is not None:
+        singletons = np.where(np.array(clst_mask.shape) == 1)[0]
+        if len(singletons) > 0:
+            clst_mask = np.squeeze(clst_mask, axis=tuple(singletons))
+        if (cluster_colors is None and isinstance(cluster_idx, list)
+            and len(cluster_idx) > 1):
+            clst_mask = clst_mask.any(axis=0)
 
     # Viz rules:
     # ----------
@@ -314,7 +315,8 @@ def _mark_topo_channels(topo, clst_mask, mark_kwargs, cluster_colors,
     else:
         mark_kwargs = dict(markersize=5)
 
-    multi_clusters = isinstance(cluster_idx, list) and len(cluster_idx) > 1
+    multi_clusters = (isinstance(cluster_idx, list) and len(cluster_idx) > 1
+                      and cluster_colors is not None)
     if multi_clusters:
         n_clusters = clst_mask.shape[0]
         for clst_idx in range(n_clusters):

--- a/borsar/cluster/viz.py
+++ b/borsar/cluster/viz.py
@@ -72,7 +72,7 @@ def plot_cluster_contribution(clst, dimension, picks=None, axis=None):
 # FIXME - allow for channel sorting (by region and y position)
 def plot_cluster_chan(clst, cluster_idx=None, dims=None, vmin=None, vmax=None,
                       mark_clst_prop=0.65, mark_kwargs=None,
-                      cluster_colors=None,**kwargs):
+                      cluster_colors=None, **kwargs):
     '''Plot cluster in sensor space.
 
     Parameters

--- a/borsar/cluster/viz.py
+++ b/borsar/cluster/viz.py
@@ -71,15 +71,16 @@ def plot_cluster_contribution(clst, dimension, picks=None, axis=None):
 
 # FIXME - allow for channel sorting (by region and y position)
 def plot_cluster_chan(clst, cluster_idx=None, dims=None, vmin=None, vmax=None,
-                      mark_clst_prop=0.65, mark_kwargs=None, **kwargs):
+                      mark_clst_prop=0.65, mark_kwargs=None,
+                      cluster_colors=None,**kwargs):
     '''Plot cluster in sensor space.
 
     Parameters
     ----------
     clst : Clusters
         Clusters object to use in plotting.
-    cluster_idx : int
-        Cluster index to plot.
+    cluster_idx : int | list
+        Cluster index or list of cluster indices to plot.
     dims : str | list of str | None
         Dimensions to visualize. By default (``None``) only spatial dimension
         is plotted.
@@ -98,6 +99,8 @@ def plot_cluster_chan(clst, cluster_idx=None, dims=None, vmin=None, vmax=None,
         participating in selected cluster. For example:
         ``mark_kwargs={'markersize': 3}`` to change the size of the markers.
         ``None`` defaults to ``{'markersize: 5'}``.
+    cluster_colors : list | None, optional
+        List of cluster colors if plotting multiple clusters.
     **kwargs : additional arguments
         Additional arguments used in aggregation, defining the points to
         select (if argument value is a list of float) or the range to
@@ -154,6 +157,10 @@ def plot_cluster_chan(clst, cluster_idx=None, dims=None, vmin=None, vmax=None,
     n_elements = clst_stat.shape[1] if clst_stat.ndim > len(dim_idx) else 1
     vmin, vmax = _get_clim(clst_stat, vmin=vmin, vmax=vmax,
                            pysurfer=False)
+
+    if len(cluster_idx) > 1 and cluster_colors is None:
+        clst_mask = clst_mask.any(axis=0)
+
     # Viz rules:
     # ----------
     # 1. if 1 spatial dim is plotted -> Topo
@@ -172,21 +179,10 @@ def plot_cluster_chan(clst, cluster_idx=None, dims=None, vmin=None, vmax=None,
             topo.solid_lines()
 
             # FIXME: labels axes also when resulting from idx reduction
-            _label_topos(topo, dim_kwargs)
+            _label_topos(clst, topo, dim_kwargs, idx)
 
             # mark cluster channels
-            if clst_mask is not None and clst_mask.any():
-                if mark_kwargs is not None:
-                    if 'markersize' not in mark_kwargs:
-                        mark_kwargs.update({'markersize': 5})
-                else:
-                    mark_kwargs = dict(markersize=5)
-
-                if n_elements == 1:
-                    topo.mark_channels(clst_mask, **mark_kwargs)
-                else:
-                    for idx, tp in enumerate(topo):
-                        tp.mark_channels(clst_mask[:, idx], **mark_kwargs)
+            _mark_topo_channels(topo, clst_mask, mark_kwargs, cluster_colors)
 
             return topo
         else:
@@ -217,11 +213,17 @@ def plot_cluster_chan(clst, cluster_idx=None, dims=None, vmin=None, vmax=None,
         if not (np.sort(dim_idx) == dim_idx).all():
             clst_stat = clst_stat.T
             if clst_mask is not None:
-                clst_mask = clst_mask.T
+                clst_mask = clst_mask.transpose(clst_mask.ndim - 1,
+                                                clst_mask.ndim - 2)
 
         # get dimension coords
         x_axis = _get_dimcoords(clst, dim_idx[1], idx[dim_idx[1]])
         y_axis = _get_dimcoords(clst, dim_idx[0], idx[dim_idx[0]])
+
+        if clst_mask.ndim > 2 and outlines and cluster_colors is not None:
+            line_kwargs = plotfun_kwargs.get('line_kwargs', dict())
+            line_kwargs['color'] = cluster_colors
+            plotfun_kwargs['line_kwargs'] = line_kwargs
 
         axs = heatmap(clst_stat, mask=clst_mask, outlines=outlines,
                       x_axis=x_axis, y_axis=y_axis, vmin=vmin, vmax=vmax,
@@ -257,10 +259,11 @@ def _label_axis(ax, clst, dim_idx, ax_dim):
             ax.set_yticks([])
 
 
-def _label_topos(topo, dim_kwargs):
+def _label_topos(clst, topo, dim_kwargs, idx):
     '''Label cluster topoplots with relevant units.'''
 
-    if len(dim_kwargs) == 1:
+    n_kwargs = len(dim_kwargs)
+    if n_kwargs == 1:
         # currently works only for one selected dimension
         dim = list(dim_kwargs.keys())[0]
         unit = _get_units(dim)
@@ -276,3 +279,48 @@ def _label_topos(topo, dim_kwargs):
             # range
             ttl = '{} - {} {}'.format(*labels, unit)
             topo.axes.set_title(ttl, fontsize=12)
+    elif n_kwargs == 0:
+        # if idx for non-spatial dimensions is not (None, None, None)
+        good_idx = [isinstance(ix, slice) and not ix == slice(None)
+                    for ix in idx]
+        good_idx = np.where(good_idx)[0]
+        good_idx = good_idx[good_idx > 0]
+        if len(good_idx) > 0:
+            range = idx[good_idx[0]]
+            dim = clst.dimnames[good_idx[0]]
+            unit = _get_units(dim)
+            values = clst.dimcoords[good_idx[0]][range]
+            labels = [str(v) for v in values[[0, -1]]]
+            ttl = '{} - {} {}'.format(*labels, unit)
+            topo.axes.set_title(ttl, fontsize=12)
+
+
+def _mark_topo_channels(topo, clst_mask, mark_kwargs, cluster_colors):
+    '''Mark topo channels contributing to clusters.'''
+    if clst_mask is None or not clst_mask.any():
+        return
+
+    n_topos = len(topo)
+    if mark_kwargs is not None:
+        if 'markersize' not in mark_kwargs:
+            mark_kwargs.update({'markersize': 5})
+    else:
+        mark_kwargs = dict(markersize=5)
+
+    multi_clusters = clst_mask.ndim > 1 + int(n_topos > 1)
+    if multi_clusters:
+        n_clusters = clst_mask.shape[0]
+        for clst_idx in range(n_clusters):
+            mark_kwargs['markerfacecolor'] = cluster_colors[clst_idx]
+            if n_topos == 1:
+                topo.mark_channels(clst_mask[clst_idx], **mark_kwargs)
+            else:
+                for idx, tp in enumerate(topo):
+                    tp.mark_channels(clst_mask[clst_idx, :, idx],
+                                     **mark_kwargs)
+    else:
+        if n_topos == 1:
+            topo.mark_channels(clst_mask, **mark_kwargs)
+        else:
+            for idx, tp in enumerate(topo):
+                tp.mark_channels(clst_mask[:, idx], **mark_kwargs)

--- a/borsar/cluster/viz.py
+++ b/borsar/cluster/viz.py
@@ -171,11 +171,6 @@ def plot_cluster_chan(clst, cluster_idx=None, dims=None, vmin=None, vmax=None,
                         **plotfun_kwargs)
             topo.solid_lines()
 
-            # FIXME: temporary hack to make all channels more visible
-            # FIXME: this could be done via .set_... on relevant object
-            # topo.mark_channels(np.arange(len(clst_stat)), markersize=2,
-            #                    markerfacecolor='k', linewidth=0.)
-
             # FIXME: labels axes also when resulting from idx reduction
             _label_topos(topo, dim_kwargs)
 

--- a/borsar/cluster/viz.py
+++ b/borsar/cluster/viz.py
@@ -158,7 +158,8 @@ def plot_cluster_chan(clst, cluster_idx=None, dims=None, vmin=None, vmax=None,
     vmin, vmax = _get_clim(clst_stat, vmin=vmin, vmax=vmax,
                            pysurfer=False)
 
-    if len(cluster_idx) > 1 and cluster_colors is None:
+    if (cluster_colors is None and isinstance(idx, list)
+        and clst_mask is not None):
         clst_mask = clst_mask.any(axis=0)
 
     # Viz rules:
@@ -307,7 +308,7 @@ def _mark_topo_channels(topo, clst_mask, mark_kwargs, cluster_colors):
     else:
         mark_kwargs = dict(markersize=5)
 
-    multi_clusters = clst_mask.ndim > 1 + int(n_topos > 1)
+    multi_clusters = clst_mask.ndim > (1 + int(n_topos > 1))
     if multi_clusters:
         n_clusters = clst_mask.shape[0]
         for clst_idx in range(n_clusters):

--- a/borsar/freq.py
+++ b/borsar/freq.py
@@ -314,7 +314,7 @@ class PSD(*mixins):
         has_new_mne = version.parse(mne.__version__) >= version.parse('0.20.0')
         if has_new_mne:
             fig, picks_list, titles_list, units_list, scalings_list, \
-                ax_list, make_label, xlabels_list =  _set_psd_plot_params(
+                ax_list, make_label, xlabels_list = _set_psd_plot_params(
                     self.info, proj, picks, ax, area_mode)
         else:
             fig, picks_list, titles_list, units_list, scalings_list, ax_list, \

--- a/borsar/stats.py
+++ b/borsar/stats.py
@@ -63,7 +63,7 @@ def format_pvalue(pvalue):
 
 def _handle_preds(preds):
     '''Reshape predictors, add constant term if not present.'''
-    assert preds.ndim < 3 , '`preds` must be 1d or 2d array.'
+    assert preds.ndim < 3, '`preds` must be 1d or 2d array.'
     if preds.ndim == 1:
         preds = np.atleast_2d(preds).T
 

--- a/borsar/tests/test_viz.py
+++ b/borsar/tests/test_viz.py
@@ -159,7 +159,7 @@ def test_outlines():
     for c1, c2 in zip(cntr, correct_cntr):
         np.testing.assert_equal(c1, c2)
 
-    # add test for outlines with extent
+    # TODO - add test for outlines with extent
     cntr = _create_cluster_contour(data, extent=(0, 10, 5.25, 7.75))
 
 
@@ -184,6 +184,23 @@ def test_heatmap():
 
     plt.imshow(data)
     _add_image_mask(msk)
+    plt.close('all')
+
+    msk = np.stack([data < 0.25, data > 0.75], axis=0)
+    heatmap(data, x_axis=x, y_axis=y, mask=msk, outlines=True)
+
+    img = heatmap(data, mask=msk, outlines=True, colorbar=False,
+                  line_kwargs={'color': ['w', 'r']})
+
+    # assert that line colors have both white and red colors
+    chldr = img.axes.get_children()
+    lines = [chld for chld in chldr if 'Line2D' in str(chld)]
+    line_colors = [l.get_color() for l in lines]
+    if msk[0].any():
+        assert 'w' in line_colors
+    if msk[1].any():
+        assert 'r' in line_colors
+
     plt.close('all')
 
 

--- a/borsar/utils.py
+++ b/borsar/utils.py
@@ -183,8 +183,13 @@ def read_info(fname):
             mntg = mne.channels.make_dig_montage(ch_pos=ch_pos)
 
     # create info
-    info = mne.create_info(ch_names, data_dict['sfreq'],
-                           ch_types=ch_type, montage=mntg, verbose=False)
+    try:
+        info = mne.create_info(ch_names, data_dict['sfreq'],
+                               ch_types=ch_type, montage=mntg, verbose=False)
+    except TypeError:
+        info = mne.create_info(ch_names, data_dict['sfreq'],
+                               ch_types=ch_type, verbose=False)
+        info.set_montage(mntg)
     return info
 
 


### PR DESCRIPTION
Allow to define cluster colors with for example `cluster_colors=['white', 'gray']` when using multiple clusters.

## TODOs:
- [x] make heatmap accept multiple masks
- [x] `clst.plot([0, 1], time=[0.1, 0.11, 0.12, 0.13], cluster_colors=['w', 'gray'])` works
- [x] `clst.plot([0, 1], dims=['chan', 'time'], cluster_colors=['w', 'gray'])` works
- [x] `clst.plot(cluster_idx=3)` now gives a text label for the averaged range
- [x] tests ... (some things may be left uncovered, it is a little hard to see with travis and codecov working unreliably)

fixes #24