### PR TITLE
add min_adj_ch to numba 3d clustering

### DIFF
--- a/borsar/cluster/label.py
+++ b/borsar/cluster/label.py
@@ -127,6 +127,8 @@ def _get_cluster_fun(data, adjacency=None, backend='numpy', min_adj_ch=0):
 
 
 # TODO : add tail=0 to control for tail selection
+# TODO: split lower level stuff to _find_clusters which would be called by
+#       higher-order clustering functions (circumventing all the checks etc.)
 def find_clusters(data, threshold, adjacency=None, cluster_fun=None,
                   backend='auto', mne_reshape_clusters=True, min_adj_ch=0):
     """Find clusters in data array given cluster membership threshold and
@@ -166,6 +168,7 @@ def find_clusters(data, threshold, adjacency=None, cluster_fun=None,
     cluster_stats : numpy array
         Array with cluster statistics - usually sum of cluster members' values.
     """
+    # FIXME - these lines should be put in _get_cluster_fun
     if cluster_fun is None and backend == 'auto':
         backend = 'mne' if data.ndim < 3 else 'auto'
     if data.ndim < 3 and min_adj_ch > 0:
@@ -189,7 +192,6 @@ def find_clusters(data, threshold, adjacency=None, cluster_fun=None,
                                                  as _setup_connectivity)
             argname = 'adjacency'
 
-        # FIXME more checks for adjacency and data when using mne!
         if adjacency is not None and isinstance(adjacency, np.ndarray):
             if not sparse.issparse(adjacency):
                 adjacency = sparse.coo_matrix(adjacency)

--- a/borsar/cluster/label.py
+++ b/borsar/cluster/label.py
@@ -7,10 +7,17 @@ from ..utils import has_numba
 # TODO:
 # - [ ] compare speed against mne clustering
 # - [x] add min_adj_ch (minimum adjacent channels)
-# - [ ] wait with relabeling till the end (less computationally expensive)
+# - [x] wait with relabeling till the end (tried that and it was slower)
 def cluster_3d(data, adjacency, min_adj_ch=0):
     '''
     Cluster three-dimensional data given adjacency matrix.
+
+    WARNING, ``min_adj_ch > 0`` can modify data in-pace! Pass a copy of the
+    data (``data.copy()``) if you don't want that to happen.
+    This in-place modification does not happen in ``find_clusters`` function
+    which passes ``data > threshold`` to lower-level functions like this one
+    (so it creates new data array each time that is used only in lower-level
+    clustering function).
 
     Parameters
     ----------
@@ -21,7 +28,7 @@ def cluster_3d(data, adjacency, min_adj_ch=0):
         adjacency. If ``adjacency[i, j]`` is ``True`` that means channel ``i``
         and ``j`` are adjacent.
     min_adj_ch : int
-        Number of minimum adjacent channels/vertices for given point to be
+        Number of minimum adjacent True channels/vertices for given point to be
         included in a cluster.
 
     Returns
@@ -39,6 +46,7 @@ def cluster_3d(data, adjacency, min_adj_ch=0):
 
 
 def _per_channel_adjacency(data, adjacency):
+    '''Identify clusters within channels.'''
     from skimage.measure import label
 
     # data has to be bool
@@ -62,6 +70,7 @@ def _per_channel_adjacency(data, adjacency):
 
 
 def _cross_channel_adjacency(clusters, adjacency, min_adj_ch=0):
+    '''Connect clusters identified within channels.'''
     n_chan = clusters.shape[0]
     # unrolled views into clusters for ease of channel comparison:
     unrolled = [clusters[ch, :].ravel() for ch in range(n_chan)]
@@ -111,15 +120,12 @@ def _get_cluster_fun(data, adjacency=None, backend='numpy', min_adj_ch=0):
     if data.ndim == 3 and has_adjacency:
         if backend in ['numba', 'auto']:
             hasnb = has_numba()
-            if hasnb and min_adj_ch == 0:
+            if hasnb:
                 from .label_numba import cluster_3d_numba
                 return cluster_3d_numba
             elif backend == 'numba' and not hasnb:
                 raise ValueError('You need numba package to use the "numba" '
                                  'backend.')
-            elif backend == 'numba' and min_adj_ch > 0:
-                raise ValueError('Numba backend does allow for `min_adj_ch` '
-                                 '> 0.')
             else:
                 return cluster_3d
         else:
@@ -127,8 +133,6 @@ def _get_cluster_fun(data, adjacency=None, backend='numpy', min_adj_ch=0):
 
 
 # TODO : add tail=0 to control for tail selection
-# TODO: split lower level stuff to _find_clusters which would be called by
-#       higher-order clustering functions (circumventing all the checks etc.)
 def find_clusters(data, threshold, adjacency=None, cluster_fun=None,
                   backend='auto', mne_reshape_clusters=True, min_adj_ch=0):
     """Find clusters in data array given cluster membership threshold and
@@ -157,32 +161,41 @@ def find_clusters(data, threshold, adjacency=None, cluster_fun=None,
         the original data shape after obtaining them from mne. Not used for
         other backends.
     min_adj_ch
-        FIXME
+        Number of minimum adjacent channels/vertices above ``threshold`` for
+        given point to be included in a cluster.
 
     Returns
     -------
     clusters : list
         List of boolean arrays informing about membership in consecutive
-        clusters. For example `clusters[0]` informs about data points that
+        clusters. For example ``clusters[0]`` informs about data points that
         belong to the first cluster.
     cluster_stats : numpy array
         Array with cluster statistics - usually sum of cluster members' values.
     """
+    findfunc, adjacency, addarg,  = _prepare_clustering(
+        data, adjacency, cluster_fun, backend, min_adj_ch=min_adj_ch)
+    clusters, cluster_stats = findfunc(data, threshold, adjacency, addarg,
+                                       min_adj_ch=min_adj_ch, full=True)
+
+    return clusters, cluster_stats
+
+
+def _prepare_clustering(data, adjacency, cluster_fun, backend, min_adj_ch=0):
+    '''Prepare clustering - perform checks and create necessary variables.'''
     # FIXME - these lines should be put in _get_cluster_fun
     if cluster_fun is None and backend == 'auto':
-        backend = 'mne' if data.ndim < 3 else 'auto'
+        backend = 'mne' if data.ndim < 3 and min_adj_ch == 0 else 'auto'
+
     if data.ndim < 3 and min_adj_ch > 0:
         raise ValueError('currently ``min_adj_ch`` is implemented only for'
                          ' 3d clustering.')
 
+    # mne_reshape_clusters=True,
     if backend == 'mne':
         if min_adj_ch > 0:
             raise ValueError('mne backend does not supprot ``min_adj_ch`` '
                              'filtering')
-        # mne clustering
-        # --------------
-        from mne.stats.cluster_level import (
-            _find_clusters, _cluster_indices_to_mask)
 
         try:
             from mne.stats.cluster_level import _setup_connectivity
@@ -199,44 +212,55 @@ def find_clusters(data, threshold, adjacency=None, cluster_fun=None,
                 adjacency = _setup_connectivity(adjacency, np.prod(data.shape),
                                                 data.shape[0])
 
-        orig_data_shape = data.shape
-        kwargs = {argname: adjacency}
-        data = (data.ravel() if adjacency is not None else data)
-        clusters, cluster_stats = _find_clusters(
-            data, threshold=threshold, tail=0, **kwargs)
-
-        if mne_reshape_clusters:
-            if adjacency is not None:
-                clusters = _cluster_indices_to_mask(clusters,
-                                                    np.prod(data.shape))
-            clusters = [clst.reshape(orig_data_shape) for clst in clusters]
+        return _find_clusters_mne, adjacency, argname
     else:
-        # borsar clustering
-        # -----------------
         if cluster_fun is None:
             cluster_fun = _get_cluster_fun(data, adjacency=adjacency,
                                            min_adj_ch=min_adj_ch,
                                            backend=backend)
-        # positive clusters
-        # -----------------
-        pos_clusters = cluster_fun(data > threshold, adjacency=adjacency,
-                                   min_adj_ch=min_adj_ch)
+        return _find_clusters_borsar, adjacency, cluster_fun
 
-        # TODO - consider numba optimization of this part too:
-        cluster_id = np.unique(pos_clusters)[1:]
-        pos_clusters = [pos_clusters == id for id in cluster_id]
-        cluster_stats = [data[clst].sum() for clst in pos_clusters]
 
-        # negative clusters
-        # -----------------
-        neg_clusters = cluster_fun(data < -threshold, adjacency=adjacency,
-                                   min_adj_ch=min_adj_ch)
+def _find_clusters_mne(data, threshold, adjacency, argname, min_adj_ch=0,
+                       full=True):
+    from mne.stats.cluster_level import (
+        _find_clusters, _cluster_indices_to_mask)
 
-        # TODO - consider numba optimization of this part too:
-        cluster_id = np.unique(neg_clusters)[1:]
-        neg_clusters = [neg_clusters == id for id in cluster_id]
-        cluster_stats = np.array(cluster_stats + [data[clst].sum()
-                                                  for clst in neg_clusters])
-        clusters = pos_clusters + neg_clusters
+    orig_data_shape = data.shape
+    kwargs = {argname: adjacency}
+    data = (data.ravel() if adjacency is not None else data)
+    clusters, cluster_stats = _find_clusters(
+        data, threshold=threshold, tail=0, **kwargs)
+
+    if full:
+        if adjacency is not None:
+            clusters = _cluster_indices_to_mask(clusters,
+                                                np.prod(data.shape))
+        clusters = [clst.reshape(orig_data_shape) for clst in clusters]
+
+    return clusters, cluster_stats
+
+
+def _find_clusters_borsar(data, threshold, adjacency, cluster_fun,
+                          min_adj_ch=0, full=True):
+    pos_clusters = cluster_fun(data > threshold, adjacency=adjacency,
+                               min_adj_ch=min_adj_ch)
+
+    # TODO - consider numba optimization of this part too:
+    cluster_id = np.unique(pos_clusters)[1:]
+    pos_clusters = [pos_clusters == id for id in cluster_id]
+    cluster_stats = [data[clst].sum() for clst in pos_clusters]
+
+    # negative clusters
+    # -----------------
+    neg_clusters = cluster_fun(data < -threshold, adjacency=adjacency,
+                               min_adj_ch=min_adj_ch)
+
+    # TODO - consider numba optimization of this part too:
+    cluster_id = np.unique(neg_clusters)[1:]
+    neg_clusters = [neg_clusters == id for id in cluster_id]
+    cluster_stats = np.array(cluster_stats + [data[clst].sum()
+                                              for clst in neg_clusters])
+    clusters = pos_clusters + neg_clusters
 
     return clusters, cluster_stats

--- a/borsar/cluster/label_numba.py
+++ b/borsar/cluster/label_numba.py
@@ -1,16 +1,48 @@
 import numpy as np
+import numba
 from numba import jit
 
 
-def cluster_3d_numba(data, adjacency=None):
-    """Cluster data using numba-optimized functions."""
+def cluster_3d_numba(data, adjacency=None, min_adj_ch=0):
+    """Cluster data using numba-optimized functions.
+
+    WARNING, ``min_adj_ch > 0`` can modify data in-pace! Pass a copy of the
+    data (``data.copy()``) if you don't want that to happen.
+    This in-place modification does not happen in ``find_clusters`` function
+    which passes ``data > threshold`` to lower-level functions like this one
+    (so it creates new data array each time that is used only in lower-level
+    clustering function).
+
+    Parameters
+    ----------
+    data : numpy array
+        Matrix boolean array of shape ``(channels, dim2, dim3)``.
+    adjacency : numpy array
+        Twodimensional boolean matrix with information about channel/vertex
+        adjacency. If ``adjacency[i, j]`` is ``True`` that means channel ``i``
+        and ``j`` are adjacent.
+    min_adj_ch : int
+        Number of minimum adjacent True channels/vertices for given point to be
+        included in a cluster.
+
+    Returns
+    -------
+    clusters : array of int
+        3d integer matrix with cluster labels.
+    """
     # data has to be bool
     assert data.dtype == np.bool
 
     # nested import
     from skimage.measure import label
 
+    if min_adj_ch > 0:
+        adj_ch = _check_adj_ch(data, adjacency)
+        msk = adj_ch < min_adj_ch
+        data[msk] = False  # warning, in-place modification
+
     # label each channel separately
+    # TODO - consider writing this loop in numba - it will be useful anyway
     clusters = np.zeros(data.shape, dtype='int')
     max_cluster_id = 0
     n_chan = data.shape[0]
@@ -24,12 +56,11 @@ def cluster_3d_numba(data, adjacency=None):
             clusters[ch, clusters[ch] > 0] += max_cluster_id
         max_cluster_id += num_clusters
 
-    # unrolled views into clusters for ease of channel comparison:
-    return relabel_clusters(clusters, adjacency)
+    return _relabel_clusters(clusters, adjacency)
 
 
 @jit(nopython=True)
-def replace_numba_3d(mat, val1, val2):
+def _replace_numba_3d(mat, val1, val2):
     """Numba version of ``mat[mat == val1] = val2`` for 3d arrays.
 
     About 4.6 faster than normal numpy.
@@ -44,7 +75,7 @@ def replace_numba_3d(mat, val1, val2):
 
 
 @jit(nopython=True)
-def relabel_clusters(clusters, chan_conn):
+def _relabel_clusters(clusters, chan_conn):
     """Check channel neighbours and merge clusters across channels."""
     n_chan, n_x, n_y = clusters.shape
     for ch in range(n_chan - 1):  # last channel will be already checked
@@ -61,5 +92,28 @@ def relabel_clusters(clusters, chan_conn):
                             if val2 and not (val1 == val2):
                                 c1 = min(val1, val2)
                                 c2 = max(val1, val2)
-                                clusters = replace_numba_3d(clusters, c2, c1)
+                                clusters = _replace_numba_3d(clusters, c2, c1)
     return clusters
+
+
+@jit(nopython=True)
+def _check_adj_ch(clusters, chan_conn):
+    """Check number of channel neighbours."""
+    n_chan, n_x, n_y = clusters.shape
+    adj_ch = np.zeros((n_chan, n_x, n_y), dtype=numba.int32)
+
+    for ch in range(n_chan - 1):  # last channel will be already checked
+        # get unchecked neighbours
+        neighbours = np.where(chan_conn[ch + 1:, ch])[0]
+        if neighbours.shape[0] > 0:
+            neighbours += ch + 1
+            for idx1 in range(n_x):
+                for idx2 in range(n_y):
+                    val1 = clusters[ch, idx1, idx2]
+                    if val1:
+                        for ngb in neighbours:
+                            val2 = clusters[ngb, idx1, idx2]
+                            if val2:
+                                adj_ch[ch, idx1, idx2] = (
+                                    adj_ch[ch, idx1, idx2] + 1)
+    return adj_ch

--- a/borsar/cluster/obj.py
+++ b/borsar/cluster/obj.py
@@ -484,9 +484,7 @@ class Clusters(object):
                 limits.append(slice(None))
         return tuple(limits)
 
-    # TODO - make sure that when one dim is specified with coords and other
-    #        with mass to retain, the mass is taken only from the part
-    #        specified? (this is done in get_limits with `idx` variable)
+    # TODO - do not use get_index() for limit calculations - division of labor!
     def get_index(self, cluster_idx=None, ignore_dims=None, retain_mass=0.65,
                   **kwargs):
         '''

--- a/borsar/cluster/utils.py
+++ b/borsar/cluster/utils.py
@@ -556,6 +556,67 @@ def _index_from_dim(dimnames, dimcoords, **kwargs):
     return tuple(idx)
 
 
+# TODO: add _is_spatial_dim
+# TODO: add errors
+def _prepare_dimindex_plan(dimnames, **kwargs):
+    n_dims = len(dimnames)
+    specified = [dim in kwargs for dim in dimnames]
+    plan =(None,) * n_dims
+    if not any(specified):
+        return plan, kwargs
+
+    for idx in np.where(specified)[0]:
+        dimindex = kwargs[dimnames[idx]]
+
+        if isinstance(dimindex, tuple):
+            if len(dimindex) == 2:
+                plan[idx] = 'range'
+            else:
+                msg = 'TEMP!'
+                raise ValueError(msg)
+        elif isinstance(dimindex, Integral):
+            plan[idx] = 'singular'
+        elif isinstance(dimindex, (list, np.ndarray)):
+            # squeeze array?
+            numel = len(dimindex)
+            if numel == 0:
+                # TODO - what do we do with empty list?
+                msg = 'TEMP!'
+                raise ValueError(msg)
+            elif numel == 1:
+                plan[idx] = 'singular'
+                kwargs[dimnames[idx]] = dimindex[0]
+            else:
+                plan[idx] = 'multi'
+        elif isinstance(dimindex, str):
+            pat = r'[0-9]{1,3}(\.[0-9]*)?%( vol)?'
+            match = re.fullmatch(pat, dimindex)
+            if match is not None:
+                plan[idx] = 'volume'
+                value = float(dimindex.replace('vol', '').replace(' ', '')
+                              .replace('%', ''))
+                if value > 100. or value < 0.:
+                    raise ValueError('The percentage value has to be >= '
+                                     '0 and <= 100.')
+                kwargs[dimnames[idx]] = value
+            else:
+                # TODO: could be a channel name
+                if _is_spatial_dim(dimnames[idx]):
+                    plan[idx] = 'spatial name'
+        elif isinstance(dimindex, slice):
+            if dimindex == slice(None):
+                # "take everyting"
+                plan[idx] = 'full'
+            else:
+                # first it will be ValueError
+                msg = 'TEMP!'
+                raise ValueError(msg)
+        else:
+            msg = 'TEMP!'
+            raise TypeError(msg)
+
+        # LATER: check multi for channel/vertex indices or names
+
 def _clean_up_indices(idx):
     '''Turn multiple fancy indexers into what is needed with ``np._ix``.'''
     n_indices = len(idx)


### PR DESCRIPTION
- [x] `min_adj_ch` added to `cluster_3d_numba`
- [x] added warning in the docstring of `cluster_3d` and `cluster_3d_numba` that these lower-level functions modify `data` array in-place when `min_adj_ch > 0`. This is ok, as it does not affect `find_clusters` which passes copies (`data > threshold` for example) to `cluster_fun`
- [ ] for the reason above I could make `cluster_3d` and `cluster_3d_numba` private
- [x] restructure `find_clusters` to allow cluster permutation tests to take advantage of splitting preparatory steps (that need to be only done once) into `_prepare_clustering` 
- [x] add tests for numba `min_adj_ch`