### PR TITLE
ENH: add 2d numba clustering; DEV: Make low-level clustering functions private

### DIFF
--- a/borsar/__init__.py
+++ b/borsar/__init__.py
@@ -1,1 +1,4 @@
-from . import (channels, csd, freq, project, stats, utils, viz)
+from borsar import (channels, cluster, csd, freq, project, stats, utils, viz)
+
+from borsar.cluster import Clusters, find_clusters, read_cluster
+from borsar.utils import find_index, find_range, write_info, read_info

--- a/borsar/cluster/__init__.py
+++ b/borsar/cluster/__init__.py
@@ -1,4 +1,4 @@
 from .obj import Clusters, read_cluster
-from .label import find_clusters, cluster_3d
+from .label import find_clusters
 from .stats import cluster_based_regression
 from .utils import construct_adjacency_matrix

--- a/borsar/cluster/label.py
+++ b/borsar/cluster/label.py
@@ -144,8 +144,8 @@ def _get_cluster_fun(data, adjacency=None, backend='numpy', min_adj_ch=0):
 
 def _borsar_clustering_error():
     raise ValueError('borsar has specialised clustering functions only'
-                     ' for three dimensional data where the first dimen'
-                     'sion is spatial (channels or vertices). This spat'
+                     ' for three- and two-dimensional data where the first '
+                     'dimension is spatial (channels or vertices). This spat'
                      'ial dimension requires adjacency matrix defining '
                      'adjacency relationships. Your data is either not'
                      'three-dimensional or you did not provide an adja'

--- a/borsar/cluster/label.py
+++ b/borsar/cluster/label.py
@@ -8,7 +8,7 @@ from ..utils import has_numba
 # - [ ] compare speed against mne clustering
 # - [x] add min_adj_ch (minimum adjacent channels)
 # - [x] wait with relabeling till the end (tried that and it was slower)
-def cluster_3d(data, adjacency, min_adj_ch=0):
+def _cluster_3d_numpy(data, adjacency, min_adj_ch=0):
     '''
     Cluster three-dimensional data given adjacency matrix.
 
@@ -121,15 +121,23 @@ def _get_cluster_fun(data, adjacency=None, backend='numpy', min_adj_ch=0):
         if backend in ['numba', 'auto']:
             hasnb = has_numba()
             if hasnb:
-                from .label_numba import cluster_3d_numba
-                return cluster_3d_numba
+                from .label_numba import _cluster_3d_numba
+                return _cluster_3d_numba
             elif backend == 'numba' and not hasnb:
                 raise ValueError('You need numba package to use the "numba" '
                                  'backend.')
             else:
-                return cluster_3d
+                return _cluster_3d_numpy
         else:
-            return cluster_3d
+            return _cluster_3d_numpy
+    else:
+        raise ValueError('borsar has specialised clustering functions only'
+                         ' for three dimensional data where the first dimen'
+                         'sion is spatial (channels or vertices). This spat'
+                         'ial dimension requires adjacency matrix defining '
+                         'adjacency relationships. Your data is either not'
+                         'three-dimensional or you did not provide an adja'
+                         'cency matrix for the spatial dimension')
 
 
 # TODO : add tail=0 to control for tail selection

--- a/borsar/cluster/label.py
+++ b/borsar/cluster/label.py
@@ -40,15 +40,15 @@ def _cluster_3d_numpy(data, adjacency, min_adj_ch=0):
     assert data.dtype == np.bool
 
     if min_adj_ch > 0:
-        data = _cross_channel_adjacency(data, adjacency, min_adj_ch=min_adj_ch)
+        data = _cross_channel_adjacency_3d(data, adjacency, min_adj_ch=min_adj_ch)
 
-    clusters = _per_channel_adjacency(data, adjacency)
-    clusters = _cross_channel_adjacency(clusters, adjacency)
+    clusters = _per_channel_adjacency_3d(data)
+    clusters = _cross_channel_adjacency_3d(clusters, adjacency)
 
     return clusters
 
 
-def _per_channel_adjacency(data, adjacency):
+def _per_channel_adjacency_3d(data):
     '''Identify clusters within channels.'''
     from skimage.measure import label
 
@@ -69,7 +69,7 @@ def _per_channel_adjacency(data, adjacency):
     return clusters
 
 
-def _cross_channel_adjacency(clusters, adjacency, min_adj_ch=0):
+def _cross_channel_adjacency_3d(clusters, adjacency, min_adj_ch=0):
     '''Connect clusters identified within channels.'''
     n_chan = clusters.shape[0]
     # unrolled views into clusters for ease of channel comparison:

--- a/borsar/cluster/label.py
+++ b/borsar/cluster/label.py
@@ -12,7 +12,7 @@ def _cluster_3d_numpy(data, adjacency, min_adj_ch=0):
     '''
     Cluster three-dimensional data given adjacency matrix.
 
-    WARNING, ``min_adj_ch > 0`` can modify data in-pace! Pass a copy of the
+    WARNING, ``min_adj_ch > 0`` can modify data in-place! Pass a copy of the
     data (``data.copy()``) if you don't want that to happen.
     This in-place modification does not happen in ``find_clusters`` function
     which passes ``data > threshold`` to lower-level functions like this one

--- a/borsar/cluster/label_numba.py
+++ b/borsar/cluster/label_numba.py
@@ -44,6 +44,45 @@ def _cluster_3d_numba(data, adjacency=None, min_adj_ch=0):
     return _relabel_clusters_3d(clusters, adjacency)
 
 
+def _cluster_2d_numba(data, adjacency=None, min_adj_ch=0):
+    """Cluster 2d channels x dim2 data using numba-optimized functions.
+
+    WARNING, ``min_adj_ch > 0`` can modify data in-pace! Pass a copy of the
+    data (``data.copy()``) if you don't want that to happen.
+    This in-place modification does not happen in ``find_clusters`` function
+    which passes ``data > threshold`` to lower-level functions like this one
+    (so it creates new data array each time that is used only in lower-level
+    clustering function).
+
+    Parameters
+    ----------
+    data : numpy array
+        Matrix boolean array of shape ``(channels, dim2)``.
+    adjacency : numpy array
+        Twodimensional boolean matrix with information about channel/vertex
+        adjacency. If ``adjacency[i, j]`` is ``True`` that means channel ``i``
+        and ``j`` are adjacent.
+    min_adj_ch : int
+        Number of minimum adjacent True channels/vertices for given point to be
+        included in a cluster.
+
+    Returns
+    -------
+    clusters : array of int
+        3d integer matrix with cluster labels.
+    """
+    # data has to be bool
+    assert data.dtype == np.bool
+
+    if min_adj_ch > 0:
+        adj_ch = _check_adj_ch_2d(data, adjacency)
+        msk = adj_ch < min_adj_ch
+        data[msk] = False  # warning, in-place modification
+
+    clusters = _per_channel_adjacency_2d_numba(data)
+    return _relabel_clusters_2d(clusters, adjacency)
+
+
 @jit(nopython=True)
 def _replace_numba_3d(mat, val1, val2):
     """Numba version of ``mat[mat == val1] = val2`` for 3d arrays.
@@ -103,4 +142,95 @@ def _check_adj_ch_3d(clusters, chan_conn):
                                     adj_ch[ch, idx1, idx2] + 1)
                                 adj_ch[ngb, idx1, idx2] = (
                                     adj_ch[ngb, idx1, idx2] + 1)
+    return adj_ch
+
+
+@jit(nopython=True)
+def _label_1d(data, from_idx=0):
+    n_pnts = len(data)
+    clusters = np.zeros(n_pnts)
+    is_previous = False
+    for ix in range(n_pnts):
+        if data[ix]:
+            if not is_previous:
+                is_previous = True
+                from_idx += 1
+            clusters[ix] = from_idx
+        elif is_previous:
+            is_previous = False
+
+    return clusters, from_idx
+
+
+
+@jit(nopython=True)
+def _relabel_clusters_2d(clusters, adjacency):
+    """Check channel neighbours and merge clusters across channels."""
+    n_chan, n_x = clusters.shape
+    for ch in range(n_chan - 1):  # last channel will be already checked
+        # get unchecked neighbours
+        neighbours = np.where(adjacency[ch + 1:, ch])[0]
+        if neighbours.shape[0] > 0:
+            neighbours += ch + 1
+            for idx1 in range(n_x):
+                val1 = clusters[ch, idx1]
+                if val1:
+                    for ngb in neighbours:
+                        val2 = clusters[ngb, idx1]
+                        if val2 and not (val1 == val2):
+                            c1 = min(val1, val2)
+                            c2 = max(val1, val2)
+                            clusters = _replace_numba_2d(clusters, c2, c1)
+    return clusters
+
+
+@jit(nopython=True)
+def _replace_numba_2d(mat, val1, val2):
+    """Numba version of ``mat[mat == val1] = val2`` for 2d arrays.
+
+    About [???] faster than normal numpy.
+    """
+    i1, i2 = mat.shape
+    for idx1 in range(i1):
+        for idx2 in range(i2):
+            if mat[idx1, idx2] == val1:
+                mat[idx1, idx2] = val2
+    return mat
+
+
+@jit(nopython=True)
+def _per_channel_adjacency_2d_numba(data):
+    '''Identify clusters within channels where each channel contains 1d
+    space.'''
+
+    from_idx = 0
+    n_chan, n_pnts = data.shape
+    clusters_all = np.empty((n_chan, n_pnts), dtype=np.int64)
+    # label each channel separately
+    for ch in range(n_chan):
+        clusters, from_idx = _label_1d(data[ch, :], from_idx=from_idx)
+        clusters_all[ch, :] = clusters
+
+    return clusters_all
+
+
+@jit(nopython=True)
+def _check_adj_ch_2d(clusters, adjacency):
+    """Check number of channel neighbours."""
+    n_chan, n_x = clusters.shape
+    adj_ch = np.zeros((n_chan, n_x), dtype=numba.int32)
+
+    for ch in range(n_chan - 1):  # last channel will be already checked
+        # get unchecked neighbours
+        neighbours = np.where(adjacency[ch + 1:, ch])[0]
+        if neighbours.shape[0] > 0:
+            neighbours = neighbours + ch + 1
+            for idx1 in range(n_x):
+                val1 = clusters[ch, idx1]
+                if val1:
+                    for ngb in neighbours:
+                        val2 = clusters[ngb, idx1]
+                        if val2:
+                            adj_ch[ch, idx1] += 1
+                            adj_ch[ngb, idx1] += 1
     return adj_ch

--- a/borsar/cluster/label_numba.py
+++ b/borsar/cluster/label_numba.py
@@ -41,7 +41,7 @@ def _cluster_3d_numba(data, adjacency=None, min_adj_ch=0):
         data[msk] = False  # warning, in-place modification
 
     clusters = _per_channel_adjacency_3d(data)
-    return _relabel_clusters_3d(clusters, adjacency)
+    return _cross_channel_adjacency_3d_numba(clusters, adjacency)
 
 
 def _cluster_2d_numba(data, adjacency=None, min_adj_ch=0):
@@ -80,7 +80,7 @@ def _cluster_2d_numba(data, adjacency=None, min_adj_ch=0):
         data[msk] = False  # warning, in-place modification
 
     clusters = _per_channel_adjacency_2d_numba(data)
-    return _relabel_clusters_2d(clusters, adjacency)
+    return _cross_channel_adjacency_2d_numba(clusters, adjacency)
 
 
 @jit(nopython=True)
@@ -99,7 +99,7 @@ def _replace_numba_3d(mat, val1, val2):
 
 
 @jit(nopython=True)
-def _relabel_clusters_3d(clusters, chan_conn):
+def _cross_channel_adjacency_3d_numba(clusters, chan_conn):
     """Check channel neighbours and merge clusters across channels."""
     n_chan, n_x, n_y = clusters.shape
     for ch in range(n_chan - 1):  # last channel will be already checked
@@ -148,6 +148,7 @@ def _check_adj_ch_3d(clusters, chan_conn):
 
 @jit(nopython=True)
 def _label_1d(data, from_idx=0):
+    '''Cluster boolean values on a vector.'''
     n_pnts = len(data)
     clusters = np.zeros(n_pnts)
     is_previous = False
@@ -163,9 +164,8 @@ def _label_1d(data, from_idx=0):
     return clusters, from_idx
 
 
-
 @jit(nopython=True)
-def _relabel_clusters_2d(clusters, adjacency):
+def _cross_channel_adjacency_2d_numba(clusters, adjacency):
     """Check channel neighbours and merge clusters across channels."""
     n_chan, n_x = clusters.shape
     for ch in range(n_chan - 1):  # last channel will be already checked
@@ -182,6 +182,7 @@ def _relabel_clusters_2d(clusters, adjacency):
                             c1 = min(val1, val2)
                             c2 = max(val1, val2)
                             clusters = _replace_numba_2d(clusters, c2, c1)
+                            val1 = c1
     return clusters
 
 

--- a/borsar/cluster/label_numba.py
+++ b/borsar/cluster/label_numba.py
@@ -5,7 +5,7 @@ from numba import jit
 from .label import _per_channel_adjacency
 
 
-def cluster_3d_numba(data, adjacency=None, min_adj_ch=0):
+def _cluster_3d_numba(data, adjacency=None, min_adj_ch=0):
     """Cluster data using numba-optimized functions.
 
     WARNING, ``min_adj_ch > 0`` can modify data in-pace! Pass a copy of the

--- a/borsar/cluster/label_numba.py
+++ b/borsar/cluster/label_numba.py
@@ -117,6 +117,7 @@ def _relabel_clusters_3d(clusters, chan_conn):
                                 c1 = min(val1, val2)
                                 c2 = max(val1, val2)
                                 clusters = _replace_numba_3d(clusters, c2, c1)
+                                val1 = c1
     return clusters
 
 

--- a/borsar/cluster/label_numba.py
+++ b/borsar/cluster/label_numba.py
@@ -2,7 +2,7 @@ import numpy as np
 import numba
 from numba import jit
 
-from .label import _per_channel_adjacency
+from .label import _per_channel_adjacency_3d
 
 
 def _cluster_3d_numba(data, adjacency=None, min_adj_ch=0):
@@ -36,12 +36,12 @@ def _cluster_3d_numba(data, adjacency=None, min_adj_ch=0):
     assert data.dtype == np.bool
 
     if min_adj_ch > 0:
-        adj_ch = _check_adj_ch(data, adjacency)
+        adj_ch = _check_adj_ch_3d(data, adjacency)
         msk = adj_ch < min_adj_ch
         data[msk] = False  # warning, in-place modification
 
-    clusters = _per_channel_adjacency(data, adjacency)
-    return _relabel_clusters(clusters, adjacency)
+    clusters = _per_channel_adjacency_3d(data)
+    return _relabel_clusters_3d(clusters, adjacency)
 
 
 @jit(nopython=True)
@@ -60,7 +60,7 @@ def _replace_numba_3d(mat, val1, val2):
 
 
 @jit(nopython=True)
-def _relabel_clusters(clusters, chan_conn):
+def _relabel_clusters_3d(clusters, chan_conn):
     """Check channel neighbours and merge clusters across channels."""
     n_chan, n_x, n_y = clusters.shape
     for ch in range(n_chan - 1):  # last channel will be already checked
@@ -82,7 +82,7 @@ def _relabel_clusters(clusters, chan_conn):
 
 
 @jit(nopython=True)
-def _check_adj_ch(clusters, chan_conn):
+def _check_adj_ch_3d(clusters, chan_conn):
     """Check number of channel neighbours."""
     n_chan, n_x, n_y = clusters.shape
     adj_ch = np.zeros((n_chan, n_x, n_y), dtype=numba.int32)

--- a/borsar/cluster/tests/test_clustering.py
+++ b/borsar/cluster/tests/test_clustering.py
@@ -262,6 +262,27 @@ def test_3d_clustering_with_min_adj_ch():
         assert any([(masks_numba[1] == m).all() for m in masks])
 
 
+def test_cluster_errors():
+    from borsar.cluster.label import _get_cluster_fun
+
+    data = np.random.random((4, 10)) > 0.75
+    adj = np.zeros((4, 4), dtype='bool')
+    adj[[0, 0, 1, 1, 2, 3], [1, 3, 0, 2, 1, 0]] = True
+
+    expected_msg = 'Currently only "numba" backend can handle '
+    with pytest.raises(ValueError, match=expected_msg):
+        _get_cluster_fun(data, adj, backend='numpy')
+
+    if not has_numba():
+        expected_msg = 'You need numba package to use the "numba"'
+        with pytest.raises(ValueError, match=expected_msg):
+            _get_cluster_fun(data, adj, backend='numba')
+
+    expected_msg = 'only for three- and two-dimensional data'
+    with pytest.raises(ValueError, match=expected_msg):
+        _get_cluster_fun(data, backend='numba')
+
+
 def test_cluster_based_regression():
     np.random.seed(23)
     data_dir = _get_test_data_dir()

--- a/borsar/cluster/utils.py
+++ b/borsar/cluster/utils.py
@@ -36,6 +36,9 @@ def construct_adjacency_matrix(neighbours, ch_names=None, as_sparse=False):
         Constructed adjacency matrix.
     '''
     # checks for ch_names
+    ch_name_key = ('label' if not isinstance(neighbours, dict)
+                   else 'label' if 'label' in neighbours.keys()
+                   else 'ch_names')
     if ch_names is not None:
         ch_names_from_neighb = False
         assert isinstance(ch_names, list), 'ch_names must be a list.'
@@ -43,7 +46,7 @@ def construct_adjacency_matrix(neighbours, ch_names=None, as_sparse=False):
             'ch_names must be a list of strings'
     else:
         ch_names_from_neighb = True
-        ch_names = neighbours['label']
+        ch_names = neighbours[ch_name_key]
         if isinstance(ch_names, np.ndarray):
             ch_names = ch_names.tolist()
 
@@ -54,7 +57,7 @@ def construct_adjacency_matrix(neighbours, ch_names=None, as_sparse=False):
         if ch_names_from_neighb:
             adj = neighbours['adjacency']
         else:
-            ch_idx = [neighbours['label'].index(ch) for ch in ch_names]
+            ch_idx = [neighbours[ch_name_key].index(ch) for ch in ch_names]
             adj = neighbours['adjacency'][ch_idx][:, ch_idx]
     else:
         # fieldtrip adjacency structure


### PR DESCRIPTION
- [x] earlier `cluster_3d` is now `_cluster_3d_numpy` and `cluster_3d_numba` is now `_cluster_3d_numba`.
- [x] added 2d clustering for channels x dim2 space with `min_adj_ch`
- [x] test 2d clustering
- [x] make sure the checks for backend and relevant clustering function selection is good