### PR TITLE
FIX: fix psd.plot() on new mne version (>=0.21)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,12 @@ matrix:
       env: USE_NUMBA="no" MNE_VERSION="current"
 
     - os: linux
+      env: USE_NUMBA="no" MNE_VERSION="0.21"
+
+    - os: linux
+      env: USE_NUMBA="no" MNE_VERSION="0.20"
+
+    - os: linux
       env: USE_NUMBA="no" MNE_VERSION="0.19"
 
     - os: linux
@@ -46,6 +52,12 @@ install:
   - pip install codecov tqdm
   - if [ "${MNE_VERSION}" == "current" ]; then
       pip install mne;
+    fi
+  - if [ "${MNE_VERSION}" == "0.21" ]; then
+      pip install mne==0.21.2;
+    fi
+  - if [ "${MNE_VERSION}" == "0.20" ]; then
+      pip install mne==0.20.8;
     fi
   - if [ "${MNE_VERSION}" == "0.19" ]; then
       pip install mne==0.19;

--- a/borsar/freq.py
+++ b/borsar/freq.py
@@ -330,15 +330,15 @@ class PSD(*mixins):
                 fig, ax = plt.subplots()
             else:
                 fig = ax.figure
-            axes = [ax]
+            ax_list = [ax]
 
             units = _handle_default('units', None)
             picks = _picks_to_idx(self.info, picks)
             titles = _handle_default('titles', None)
             scalings = _handle_default('scalings', None)
 
-            make_label = len(axes) == len(fig.axes)
-            xlabels_list = [False] * (len(axes) - 1) + [True]
+            make_label = len(ax_list) == len(fig.axes)
+            xlabels_list = [False] * (len(ax_list) - 1) + [True]
             (picks_list, units_list, scalings_list, titles_list
              ) = _split_picks_by_type(self, picks, units, scalings, titles)
         elif has_20_mne:
@@ -366,24 +366,14 @@ class PSD(*mixins):
         for picks in picks_list:
             psd_list.append(inst.data[picks])
 
-        if has_new_mne:
-            _plot_psd(inst, fig, inst.freqs, psd_list, picks_list,
-                      titles_list, units_list, scalings_list, axes, make_label,
-                      color, area_mode, area_alpha, dB, estimate, average,
-                      spatial_colors, xscale, line_alpha, sphere, xlabels_list)
-        elif has_20_mne:
-            fig = _plot_psd(inst, fig, inst.freqs, psd_list, picks_list,
-                            titles_list, units_list, scalings_list, ax_list,
-                            make_label, color, area_mode, area_alpha, dB,
-                            estimate, average, spatial_colors, xscale,
-                            line_alpha, sphere, xlabels_list)
-        else:
-            fig = _plot_psd(inst, fig, inst.freqs, psd_list, picks_list,
-                            titles_list, units_list, scalings_list, ax_list,
-                            make_label, color, area_mode, area_alpha, dB,
-                            estimate, average, spatial_colors, xscale,
-                            line_alpha)
+        args = [inst, fig, inst.freqs, psd_list, picks_list, titles_list,
+                units_list, scalings_list, ax_list, make_label, color, area_mode,
+                area_alpha, dB, estimate, average, spatial_colors, xscale,
+                line_alpha]
+        if has_20_mne or has_new_mne:
+            args += [sphere, xlabels_list]
 
+        fig = _plot_psd(*args)
         plt_show(show)
         return fig
 

--- a/borsar/freq.py
+++ b/borsar/freq.py
@@ -353,7 +353,7 @@ class PSD(*mixins):
                                                   area_mode)
         del ax
 
-        crop_inst = not (fmin == 0 or fmax is None)
+        crop_inst = not (fmin == 0 and fmax is None)
         fmax = self.freqs[-1] if fmax is None else fmax
 
         inst = self.copy()
@@ -367,18 +367,18 @@ class PSD(*mixins):
             psd_list.append(inst.data[picks])
 
         if has_new_mne:
-            _plot_psd(inst, fig, self.freqs, psd_list, picks_list,
+            _plot_psd(inst, fig, inst.freqs, psd_list, picks_list,
                       titles_list, units_list, scalings_list, axes, make_label,
                       color, area_mode, area_alpha, dB, estimate, average,
                       spatial_colors, xscale, line_alpha, sphere, xlabels_list)
         elif has_20_mne:
-            fig = _plot_psd(self, fig, self.freqs[rng], psd_list, picks_list,
+            fig = _plot_psd(inst, fig, inst.freqs, psd_list, picks_list,
                             titles_list, units_list, scalings_list, ax_list,
                             make_label, color, area_mode, area_alpha, dB,
                             estimate, average, spatial_colors, xscale,
                             line_alpha, sphere, xlabels_list)
         else:
-            fig = _plot_psd(self, fig, self.freqs[rng], psd_list, picks_list,
+            fig = _plot_psd(inst, fig, inst.freqs, psd_list, picks_list,
                             titles_list, units_list, scalings_list, ax_list,
                             make_label, color, area_mode, area_alpha, dB,
                             estimate, average, spatial_colors, xscale,

--- a/borsar/freq.py
+++ b/borsar/freq.py
@@ -367,9 +367,9 @@ class PSD(*mixins):
             psd_list.append(inst.data[picks])
 
         args = [inst, fig, inst.freqs, psd_list, picks_list, titles_list,
-                units_list, scalings_list, ax_list, make_label, color, area_mode,
-                area_alpha, dB, estimate, average, spatial_colors, xscale,
-                line_alpha]
+                units_list, scalings_list, ax_list, make_label, color,
+                area_mode, area_alpha, dB, estimate, average, spatial_colors,
+                xscale, line_alpha]
         if has_20_mne or has_new_mne:
             args += [sphere, xlabels_list]
 

--- a/borsar/freq.py
+++ b/borsar/freq.py
@@ -317,9 +317,9 @@ class PSD(*mixins):
         # set up default vars
         from packaging import version
         mne_version = version.parse(mne.__version__)
-        has_new_mne = mne_version >= version.parse('0.21.0')
+        has_new_mne = mne_version >= version.parse('0.22.0')
         has_20_mne = (mne_version >= version.parse('0.20.0')
-                      and mne_version < version.parse('0.21.0'))
+                      and mne_version < version.parse('0.22.0'))
         if has_new_mne:
             from mne.defaults import _handle_default
             from mne.io.pick import _picks_to_idx

--- a/borsar/freq.py
+++ b/borsar/freq.py
@@ -360,7 +360,7 @@ class PSD(*mixins):
             psd_list.append(this_psd)
 
         if has_new_mne:
-            _plot_psd(self, fig, self.freqs, [self.data], picks_list,
+            _plot_psd(self, fig, self.freqs, psd_list, picks_list,
                       titles_list, units_list, scalings_list, axes, make_label,
                       color, area_mode, area_alpha, dB, estimate, average,
                       spatial_colors, xscale, line_alpha, sphere, xlabels_list)


### PR DESCRIPTION
mne psd plotting private code changes from mne version to version, so we have a few branches to check to keep support for older mne versions. 

Currently we support mne 0.18 and up, but in a future PR I will remove special cases and tests for mne versions older than something like 2 years.