### PR TITLE
New dimindexing

### DIFF
--- a/borsar/_mne_compat.py
+++ b/borsar/_mne_compat.py
@@ -31,7 +31,7 @@ def plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
 
     if has_1_2:
         return _plot_topomap(
-            data, pos, vmin=vmin, vmax=vmin, cmap=cmap, sensors=sensors,
+            data, pos, vmin=vmin, vmax=vmax, cmap=cmap, sensors=sensors,
             res=res, axes=axes, names=names, mask=mask,
             mask_params=mask_params, outlines=outlines, contours=contours,
             image_interp=image_interp, show=show, onselect=onselect,

--- a/borsar/_mne_compat.py
+++ b/borsar/_mne_compat.py
@@ -3,8 +3,10 @@ from mne.utils import fill_doc, _check_sphere
 from mne.viz.topomap import _plot_topomap
 
 from packaging import version
-has_0_21 = version.parse(mne.__version__) >= version.parse('0.21.dev0')
-has_1_1 = version.parse(mne.__version__) >= version.parse('1.1.dev0')
+mne_version = version.parse(mne.__version__)
+has_0_21 = mne_version >= version.parse('0.21.dev0')
+has_1_1 = mne_version >= version.parse('1.1.dev0')
+has_1_2 = mne_version >= version.parse('1.1.dev0')
 
 _BORDER_DEFAULT = 'mean'
 _EXTRAPOLATE_DEFAULT = 'head' if has_0_21 else 'box'
@@ -15,23 +17,32 @@ _EXTRAPOLATE_DEFAULT = 'head' if has_0_21 else 'box'
 @fill_doc
 def plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
                  res=64, axes=None, names=None, show_names=False, mask=None,
-                 mask_params=None, outlines='head',
-                 contours=6, image_interp='bilinear', show=True,
-                 onselect=None, extrapolate=_EXTRAPOLATE_DEFAULT,
-                 sphere=None, border=_BORDER_DEFAULT,
-                 ch_type='eeg'):
+                 mask_params=None, outlines='head', contours=6,
+                 image_interp='bilinear', show=True, onselect=None,
+                 extrapolate=_EXTRAPOLATE_DEFAULT, sphere=None,
+                 border=_BORDER_DEFAULT, ch_type='eeg', cnorm=None):
     """Plot a topographic map as image.
     (docs as in mne)
     """
     sphere = _check_sphere(sphere)
-    if has_1_1:
+    if has_1_2 or has_1_1:
         if image_interp == 'bilinear':
             image_interp = 'cubic'
+
+    if has_1_2:
+        return _plot_topomap(
+            data, pos, vmin=vmin, vmax=vmin, cmap=cmap, sensors=sensors,
+            res=res, axes=axes, names=names, mask=mask,
+            mask_params=mask_params, outlines=outlines, contours=contours,
+            image_interp=image_interp, show=show, onselect=onselect,
+            extrapolate=extrapolate, sphere=sphere, border=border,
+            ch_type=ch_type, cnorm=cnorm)
+    elif has_1_1:
         return _plot_topomap(data, pos, vmin, vmax, cmap, sensors, res, axes,
-                        names, show_names, mask, mask_params, outlines,
-                        contours, image_interp, show, onselect,
-                        extrapolate, sphere=sphere, border=border,
-                        ch_type=ch_type)
+                             names, show_names, mask, mask_params, outlines,
+                             contours, image_interp, show, onselect,
+                             extrapolate, sphere=sphere, border=border,
+                             ch_type=ch_type)
     elif has_0_21:
         return _plot_topomap(data, pos, vmin, vmax, cmap, sensors, res, axes,
                              names, show_names, mask, mask_params, outlines,

--- a/borsar/cluster/_viz3d.py
+++ b/borsar/cluster/_viz3d.py
@@ -63,6 +63,10 @@ def plot_cluster_src(clst, cluster_idx=None, aggregate='mean', set_light=True,
     if clst_mask is not None:
         clst_mask = clst_mask.any(axis=0)
 
+    if clst_mask.ndim > 1 and clst_mask.shape[1] == 1:
+        clst_mask = clst_mask[:, 0]
+        clst_stat = clst_stat[:, 0]
+
     # create label from cluster
     if clst_mask is not None:
         clst_label = _label_from_cluster(clst, clst_mask.astype('float'))
@@ -90,9 +94,13 @@ def plot_cluster_src(clst, cluster_idx=None, aggregate='mean', set_light=True,
 
     # set light
     if set_light:
-        fig = brain._figures[0][0]
-        camera_light0 = fig.scene.light_manager.lights[0]
-        camera_light0.azimuth = 0.
-        camera_light0.elevation = 42.
-        camera_light0.intensity = 1.0
+        try:
+            # works only for mayavi...
+            fig = brain._figures[0][0]
+            camera_light0 = fig.scene.light_manager.lights[0]
+            camera_light0.azimuth = 0.
+            camera_light0.elevation = 42.
+            camera_light0.intensity = 1.0
+        except AttributeError:
+            pass
     return brain

--- a/borsar/cluster/checks.py
+++ b/borsar/cluster/checks.py
@@ -190,12 +190,10 @@ def _check_dimname_arg(clst, dimname):
     return idx
 
 
-def _check_dimnames_kwargs(clst, check_dimcoords=False, ignore_dims=None,
-                           split_range_mass=False, allow_lists=True, **kwargs):
+def _check_dimnames_kwargs(clst, check_dimcoords=False, split_range_mass=False,
+                           allow_lists=True, **kwargs):
     '''Ensure that **kwargs are correct dimnames and dimcoords.
 
-    ignore_dims : list of int?
-        Dimensions to ignore.
     split_range_mass : bool
         Whether to separate range (normal) and mass indices.
     allow_lists : bool
@@ -208,10 +206,6 @@ def _check_dimnames_kwargs(clst, check_dimcoords=False, ignore_dims=None,
         raise TypeError('Clusters has to have dimcoords to use operations '
                         'on named dimensions.')
 
-    if split_range_mass:
-        normal_indexing = kwargs.copy()
-        mass_indexing = dict()
-
     for dim in kwargs.keys():
         if dim not in clst.dimnames:
             msg = ('Could not find requested dimension {}. Available '
@@ -223,20 +217,3 @@ def _check_dimnames_kwargs(clst, check_dimcoords=False, ignore_dims=None,
                    ' in this context. Use range ((min, max) tuple) or mass/'
                    'extent (float).')
             raise TypeError(msg)
-
-        if split_range_mass:
-            dval = kwargs[dim]
-            # TODO - more elaborate checks
-            dim_type = ('range' if isinstance(dval, (list, tuple, np.ndarray))
-                        else 'mass' if isinstance(dval, float) else None)
-            if dim_type == 'mass':
-                mass_indexing[dim] = dval
-                normal_indexing.pop(dim)
-            elif dim_type is None:
-                raise TypeError('The values used in dimension name indexing '
-                                'have to be either specific points (list or '
-                                'array of values), ranges (tuple of two values'
-                                ') or cluster extent to retain (float), got '
-                                '{} for dimension {}.'.format(dval, dim))
-    if split_range_mass:
-        return normal_indexing, mass_indexing

--- a/borsar/cluster/label_numba.py
+++ b/borsar/cluster/label_numba.py
@@ -33,7 +33,7 @@ def _cluster_3d_numba(data, adjacency=None, min_adj_ch=0):
         3d integer matrix with cluster labels.
     """
     # data has to be bool
-    assert data.dtype == np.bool
+    assert data.dtype == bool
 
     if min_adj_ch > 0:
         adj_ch = _check_adj_ch_3d(data, adjacency)
@@ -72,7 +72,7 @@ def _cluster_2d_numba(data, adjacency=None, min_adj_ch=0):
         3d integer matrix with cluster labels.
     """
     # data has to be bool
-    assert data.dtype == np.bool
+    assert data.dtype == bool
 
     if min_adj_ch > 0:
         adj_ch = _check_adj_ch_2d(data, adjacency)

--- a/borsar/cluster/obj.py
+++ b/borsar/cluster/obj.py
@@ -48,7 +48,7 @@ def read_cluster(fname, subjects_dir=None, src=None, info=None):
 
 # TODO - consider empty lists/arrays instead of None when no clusters...
 #      - [x] add repr so that Cluster has nice text representation
-#      - [x] make clusters and pvals keyword
+#      - [x] make stat, clusters and pvals keyword
 #            * clusters=None and pvals=None by default
 #      - [x] change order to stat, clusters, pvals
 #      - [ ] sometime: make only stat necessary
@@ -327,6 +327,7 @@ class Clusters(object):
         return clst
 
     def __repr__(self):
+        '''Clusters text representation.'''
         base_txt = '<borsar.Clusters  |  {} clusters in {} space>'
         n_clusters = len(self)
         dimnames = [_full_dimname(dimname) for dimname in self.dimnames]
@@ -490,6 +491,9 @@ class Clusters(object):
         return tuple(limits)
 
     # TODO - do not use get_index() for limit calculations - division of labor!
+    # TODO - make sure that when one dim is specified with coords and other
+    #        with mass to retain, the mass is taken only from the part
+    #        specified? (this is done in get_limits with `idx` variable)
     def get_index(self, cluster_idx=None, ignore_dims=None, retain_mass=0.65,
                   **kwargs):
         '''

--- a/borsar/cluster/obj.py
+++ b/borsar/cluster/obj.py
@@ -419,11 +419,8 @@ class Clusters(object):
     # TODO: consider continuous vs discontinuous limits
     # TODO: consider merging more with get_index?
     # TODO: rename to `get_limits()`
-    # TODO: `idx` variable was ad-hoc and is not a good API choice
-    #       this will have to be cleaned-up, preferably when writing
-    #       an example on handling cluster limits
     def get_cluster_limits(self, cluster_idx, retain_mass=0.65,
-                           dims=None, idx=None, **kwargs):
+                           dims=None, **kwargs):
         '''
         Find cluster limits based on percentage of cluster mass contribution
         to given dimensions.
@@ -478,8 +475,7 @@ class Clusters(object):
                 # use _find_mass_index_for_dim() !
                 dimname = self.dimnames[dim_idx]
                 mass = kwargs[dimname] if dimname in kwargs else retain_mass
-                contrib = self.get_contribution(cluster_idx, along=dimname,
-                                                idx=idx)
+                contrib = self.get_contribution(cluster_idx, along=dimname)
 
                 # current method - start at max and extend
                 adj = not (dim_idx == 0 and has_space)

--- a/borsar/cluster/obj.py
+++ b/borsar/cluster/obj.py
@@ -47,10 +47,6 @@ def read_cluster(fname, subjects_dir=None, src=None, info=None):
 
 
 # TODO - consider empty lists/arrays instead of None when no clusters...
-#      - [x] add repr so that Cluster has nice text representation
-#      - [x] make stat, clusters and pvals keyword
-#            * clusters=None and pvals=None by default
-#      - [x] change order to stat, clusters, pvals
 #      - [ ] sometime: make only stat necessary
 #      - [ ] add reading and writing to FieldTrip cluster structs
 class Clusters(object):
@@ -167,6 +163,7 @@ class Clusters(object):
         self.src = src
 
         # FIXME: find better way for this (maybe during safety checks earlier)
+        #        maybe just a private constructor?
         if self.info is not None and safety_checks:
             _ensure_correct_info(self)
 

--- a/borsar/cluster/obj.py
+++ b/borsar/cluster/obj.py
@@ -542,8 +542,8 @@ class Clusters(object):
                                     select=retain_mass, ignore=ignore_dims)
 
         # when retain_mass is specified it is used to get ranges for
-        # dimensions not addressed with kwargs
-        # FIXME - error if mass_indexing specified but no cluster_idx
+        # dimensions not adressed with kwargs
+        # FIXME - add error if mass_indexing specified but no cluster_idx
         if cluster_idx is not None:
             # check cluster limits only for non-indexed dimensions
             idx = _find_mass_index(self, cluster_idx, plan, kwargs, idx)

--- a/borsar/cluster/obj.py
+++ b/borsar/cluster/obj.py
@@ -438,11 +438,12 @@ class Clusters(object):
             dimensions except spatial.
         **kwargs : additional keyword arguments
             Additional arguments defining the cluster extent to retain along
-            specified dimensions. Float argument between 0. and 1. - defines
-            range that is dependent on cluster mass. For example ``time=0.75``
-            defines time range limits that retain at least 75% of the cluster
+            specified dimensions. String argument representing percentage,
+            for example ``'55.5%'`` defines a range that is dependent on
+            cluster mass. For example ``time='75 %'`` defines time range limits
+            that retain at least 75% of the cluster
             (calculated along given dimension - in this case time). If no kwarg
-            is passed for given dimension then the default value of 0.65 is
+            is passed for given dimension then the default value of '65%' is
             used - so that cluster limits are defined to retain at least 65%
             of the relevant cluster mass.
 

--- a/borsar/cluster/tests/test_cluster.py
+++ b/borsar/cluster/tests/test_cluster.py
@@ -801,7 +801,7 @@ def test_cluster_ignore_dims():
     # make sure image data is correct
     data = np.array(axs[0].images[0].get_array())
     data_agg = (clst.stat * clst.clusters[0]).sum(axis=(1, 2))
-    ix = slice(4, 6) if data_agg.argmax() == 4 else slice(5, 7)
+    ix = np.sort(data_agg.argsort()[::-1][:2])
     assert (clst.stat[ix].mean(axis=0) == data).all()
 
     # (A2) 65% volume if requested

--- a/borsar/cluster/tests/test_cluster.py
+++ b/borsar/cluster/tests/test_cluster.py
@@ -218,6 +218,23 @@ def test_dimindex_plan():
     assert_allclose(kwargs['freq'], 0.666)
 
 
+def test_expected_errors_in_plot_indexing():
+    clst = _create_random_clusters()
+
+    msg = 'If indexing with a list, the list has to be non-empty.'
+    with pytest.raises(ValueError, match=msg):
+        clst.plot(time=np.array([]))
+
+    msg = 'Indexing spatial dimension is allowed only with'
+    with pytest.raises(TypeError, match=msg):
+        clst.plot(chan=[{'a': [1, 2, 3]}, {'b': [2, 3]}])
+
+    msg = ('Sorry, picking spatial dimension using strings is '
+           'not yet supported.')
+    with pytest.raises(NotImplementedError, match=msg):
+        clst.plot(chan='A')
+
+
 def test_clusters():
     import mne
     import matplotlib.pyplot as plt

--- a/borsar/cluster/tests/test_cluster.py
+++ b/borsar/cluster/tests/test_cluster.py
@@ -795,8 +795,17 @@ def test_cluster_ignore_dims():
     clst.clusters[0] = np.zeros(clst.stat.shape, dtype='bool')
     clst.clusters[0, 4:7, 8:13, 20:26] = True
 
-    # (A) 65% channels reduced automatically
+    # (A1) 65% channels mass reduced automatically
     axs = clst.plot(cluster_idx=0, dims=['freq', 'time'])
+
+    # make sure image data is correct
+    data = np.array(axs[0].images[0].get_array())
+    data_agg = (clst.stat * clst.clusters[0]).sum(axis=(1, 2))
+    ix = slice(4, 6) if data_agg.argmax() == 4 else slice(5, 7)
+    assert (clst.stat[ix].mean(axis=0) == data).all()
+
+    # (A2) 65% volume if requested
+    axs = clst.plot(cluster_idx=0, dims=['freq', 'time'], chan='65% vol')
 
     # make sure image data is correct
     data = np.array(axs[0].images[0].get_array())

--- a/borsar/cluster/tests/test_cluster.py
+++ b/borsar/cluster/tests/test_cluster.py
@@ -7,6 +7,8 @@ import numpy as np
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 
+from numpy.testing import assert_allclose
+
 import mne
 
 import borsar
@@ -167,6 +169,40 @@ def test_cluster_utils():
     _move_axes_to(ax, x=0.123)
     assert ax[0].get_position().bounds[0] == 0.123
     assert ax[1].get_position().bounds[0] == 0.123
+
+
+def test_dimindex_plan():
+    from borsar.cluster.utils import _prepare_dimindex_plan
+
+    # range
+    plan, kwargs = _prepare_dimindex_plan(['chan', 'time'], time=(0.2, 0.35))
+    assert plan[0] is None
+    assert plan[1] == 'range'
+
+    # points and mass
+    plan, kwargs = _prepare_dimindex_plan(['chan', 'time'], chan=[1, 4, 5],
+                                          time='50%')
+    assert plan[0] == 'spatial_idx'
+    assert plan[1] == 'mass'
+    assert kwargs['time'] == 0.5
+
+    # channel names, range and volume
+    plan, kwargs = _prepare_dimindex_plan(['chan', 'freq', 'time'],
+                                          chan=['Cz', 'F3', 'Fz'],
+                                          freq=(7, 13), time='75% vol')
+    assert plan[0] == 'spatial_names'
+    assert plan[1] == 'range'
+    assert plan[2] == 'volume'
+    assert kwargs['time'] == 0.75
+
+    # single name, single
+    plan, kwargs = _prepare_dimindex_plan(['chan', 'freq', 'time'],
+                                          chan='F3', freq='66.6% mass',
+                                          time=0.3)
+    assert plan[0] == 'spatial_name'
+    assert plan[1] == 'mass'
+    assert plan[2] == 'singular'
+    assert_allclose(kwargs['freq'], 0.666)
 
 
 def test_clusters():

--- a/borsar/cluster/tests/test_cluster.py
+++ b/borsar/cluster/tests/test_cluster.py
@@ -24,7 +24,8 @@ from borsar.cluster.utils import (_check_stc, _label_from_cluster, _get_clim,
                                   _aggregate_cluster, _get_units,
                                   _get_dimcoords, _get_mass_range,
                                   _format_cluster_pvalues, _index_from_dim,
-                                  _full_dimname, _human_readable_dimlabel)
+                                  _full_dimname, _human_readable_dimlabel,
+                                  _prepare_dimindex_plan)
 from borsar.cluster.viz import _label_axis, _move_axes_to
 
 # setup
@@ -172,7 +173,6 @@ def test_cluster_utils():
 
 
 def test_dimindex_plan():
-    from borsar.cluster.utils import _prepare_dimindex_plan
 
     # range
     plan, kwargs = _prepare_dimindex_plan(['chan', 'time'], time=(0.2, 0.35))
@@ -322,7 +322,7 @@ def test_clusters():
     # get index and limits
     # --------------------
     idx = clst2.get_cluster_limits(0, retain_mass=0.75)
-    clst_0_freq_contrib[idx[1]].sum() > 0.75
+    assert clst_0_freq_contrib[idx[1]].sum() > 0.75
 
     idx = clst2.get_index(freq=(8, 10))
     assert idx[1] == slice(2, 7)

--- a/borsar/cluster/tests/test_cluster.py
+++ b/borsar/cluster/tests/test_cluster.py
@@ -827,7 +827,7 @@ def test_cluster_ignore_dims():
     # (D) test that axes are inverted when dimension order is
     axs = clst.plot(cluster_idx=0, dims=['time', 'freq'])
     data = np.array(axs[0].images[0].get_array())
-    assert (clst.stat[5:7].mean(axis=0).T == data).all()
+    assert (clst.stat[ix].mean(axis=0).T == data).all()
     assert axs[0].get_xlabel() == 'Frequency (Hz)'
     assert axs[0].get_ylabel() == 'Time (s)'
 

--- a/borsar/cluster/tests/test_cluster.py
+++ b/borsar/cluster/tests/test_cluster.py
@@ -105,18 +105,31 @@ def test_index_from_dim():
     dimnames = ['chan', 'freq', 'time']
     dimcoords = [None, np.arange(8., 12.1, step=0.5),
                  np.arange(-0.2, 0.51, step=0.1)]
-    assert _index_from_dim(dimnames[1:2], dimcoords[1:2]) == (slice(None),)
-    assert _index_from_dim(dimnames[1:], dimcoords[1:]) == (slice(None),) * 2
-    assert (_index_from_dim(dimnames, dimcoords, freq=(10, 11.5))
-            == (slice(None), slice(4, 8), slice(None)))
-    assert (_index_from_dim(dimnames, dimcoords, freq=(9.5, 10), time=(0, 0.3))
-            == (slice(None), slice(3, 5), slice(2, 6)))
-    print(_index_from_dim(dimnames, dimcoords, freq=[9.5, 10], time=(0, 0.3)))
-    idx = _index_from_dim(dimnames, dimcoords, freq=[9.5, 10], time=(0, 0.3))
-    assert (idx[0] == slice(None) and (idx[1] == [3, 4]).all()
-            and idx[2] == slice(2, 6))
-    with pytest.raises(TypeError):
-        _index_from_dim(dimnames, dimcoords, freq=[9.5], time=(0, 0.2, 0.3))
+
+    idx = _index_from_dim(dimnames[1:2], dimcoords[1:2], [None])
+    assert idx == (slice(None),)
+
+    idx = _index_from_dim(dimnames[1:], dimcoords[1:], [None, None])
+    assert idx == (slice(None),) * 2
+
+    plan, _ = _prepare_dimindex_plan(dimnames, freq=(10, 11.5))
+    idx = _index_from_dim(dimnames, dimcoords, plan, freq=(10, 11.5))
+    assert idx == (slice(None), slice(4, 8), slice(None))
+
+    kwargs = dict(freq=(9.5, 10), time=(0, 0.3))
+    plan, kwargs = _prepare_dimindex_plan(dimnames, **kwargs)
+    idx = _index_from_dim(dimnames, dimcoords, plan, **kwargs)
+    assert idx == (slice(None), slice(3, 5), slice(2, 6))
+
+    kwargs['freq'] = [9.5, 10]
+    plan, kwargs = _prepare_dimindex_plan(dimnames, **kwargs)
+    idx = _index_from_dim(dimnames, dimcoords, plan, **kwargs)
+    assert idx[0] == slice(None)
+    assert (idx[1] == [3, 4]).all()
+    assert idx[2] == slice(2, 6)
+
+    with pytest.raises(ValueError):
+        _prepare_dimindex_plan(dimnames, freq=[9.5], time=(0, 0.2, 0.3))
 
 
 def test_cluster_limits():
@@ -330,7 +343,7 @@ def test_clusters():
     idx = clst2.get_index(freq=[8, 10])
     assert (idx[1] == [2, 6]).all()
 
-    idx = clst2.get_index(cluster_idx=1, freq=0.6)
+    idx = clst2.get_index(cluster_idx=1, freq='60%')
     contrib = clst2.get_contribution(1, 'freq')
     assert contrib[idx[1]].sum() >= 0.6
 
@@ -348,9 +361,9 @@ def test_clusters():
         clst2.dimcoords = None
         clst2.get_index(freq=(8.5, 10))
     clst2.dimcoords = dcoords
-    match = (r'either specific points \(list or array of values\), ranges '
-             r'\(tuple of two values\) or cluster extent to retain \(float\)')
-    with pytest.raises(TypeError, match=match):
+    match = ('String indexer has to be either a channel name or volume/mass'
+             ' percentage')
+    with pytest.raises(ValueError, match=match):
         clst2.get_index(freq='abc')
 
     # test iteration
@@ -790,7 +803,7 @@ def test_cluster_ignore_dims():
     assert (clst.stat[5:7].mean(axis=0) == data).all()
 
     # (B) we request all channels reduced
-    axs = clst.plot(cluster_idx=0, dims=['freq', 'time'], chan=1.)
+    axs = clst.plot(cluster_idx=0, dims=['freq', 'time'], chan='100%')
 
     # make sure image data is correct
     data = np.array(axs[0].images[0].get_array())

--- a/borsar/cluster/utils.py
+++ b/borsar/cluster/utils.py
@@ -235,8 +235,8 @@ def _find_mass_index(clst, cluster_idx, plan, kwargs, idx):
 
     # update plan for dropped dimensions
     if stat_sel.ndim < n_dims:
-        this_plan = [pln for pln in plan if not pln == 'singular']
-        to_idx = [ix for ix in range(n_dims) if not pln == 'singular']
+        to_idx = [ix for ix in range(n_dims) if not plan[ix] == 'singular']
+        this_plan = [plan[ix] for ix in to_idx]
     else:
         this_plan = plan
         to_idx = list(range(n_dims))

--- a/borsar/cluster/utils.py
+++ b/borsar/cluster/utils.py
@@ -318,9 +318,16 @@ def _aggregate_cluster(clst, cluster_idx, ignore_dims=None,
     idx = _clean_up_indices(idx)
 
     if do_aggregation:
-        reduce_axes = tuple(ix for ix in range(0, clst.stat.ndim)
-                            if not (isinstance(idx[ix], (list, np.ndarray))
-                            or ix in dim_idx))
+        reduce_axes = list()
+        set_idx = 0
+        for ix in range(0, clst.stat.ndim):
+            if isinstance(idx[ix], Integral):
+                continue
+            if not (isinstance(idx[ix], (list, np.ndarray))
+                    or ix in dim_idx):
+                reduce_axes.append(set_idx)
+            set_idx += 1
+        reduce_axes = tuple(reduce_axes)
 
         # reduce spatial if present, not in dim_idx and list / array
         if (0 not in reduce_axes and _is_spatial_dim(clst.dimnames[0])

--- a/borsar/cluster/utils.py
+++ b/borsar/cluster/utils.py
@@ -255,7 +255,6 @@ def _find_mass_index(clst, cluster_idx, plan, kwargs, idx):
     return tuple(idx)
 
 
-# - [ ] unwrap _get_contrib part?
 def _find_mass_index_for_dim(stat_sel, clst_sel, type, mass, dim_idx,
                              adjacent=True):
     n_dims = stat_sel.ndim
@@ -268,7 +267,7 @@ def _find_mass_index_for_dim(stat_sel, clst_sel, type, mass, dim_idx,
         contrib = (stat_sel * clst_sel).sum(axis=tuple(reduce_dims))
     contrib = contrib / contrib.sum(axis=-1, keepdims=True)
 
-    # curent method - start at max and extend
+    # current method - start at max and extend
     lims = _get_mass_range(contrib, mass, adjacent=adjacent)
     return lims
 
@@ -331,8 +330,8 @@ def _aggregate_cluster(clst, cluster_idx, ignore_dims=None,
         Indexers for the aggregated dimensions.
         See ``borsar.Cluster.get_index``
     '''
-    listlikes = (list, np.ndarray)
-    cluster_idx = ([cluster_idx] if not isinstance(cluster_idx, listlikes)
+    list_likes = (list, np.ndarray)
+    cluster_idx = ([cluster_idx] if not isinstance(cluster_idx, list_likes)
                    else cluster_idx)
     n_clusters = len(cluster_idx)
 

--- a/borsar/cluster/utils.py
+++ b/borsar/cluster/utils.py
@@ -587,7 +587,8 @@ def _prepare_dimindex_plan(dimnames, **kwargs):
                       to be translated
     * spatial_idx   - index/indices that are already in the right coordinates,
                       no need for translation
-    * spatial_name  - channel/label name, have to be translated in a special way
+    * spatial_name  - channel/label name, have to be translated in a special
+                      way
     * spatial_names - channel/label names, have to be translated in a special
                       way
     * volume

--- a/borsar/cluster/utils.py
+++ b/borsar/cluster/utils.py
@@ -1,5 +1,5 @@
-import random
 import re
+import random
 
 import numpy as np
 from scipy import sparse
@@ -609,7 +609,9 @@ def _index_from_dim(dimnames, dimcoords, plan, **kwargs):
         elif planned in ['spatial_idx', 'spatial_singular']:
             idx.append(selection)
         elif 'spatial_name' in planned:
-            raise NotImplementedError('Sorry, not yet.')
+            msg = ('Sorry, picking spatial dimension using strings is not yet'
+                   ' supported.')
+            raise NotImplementedError(msg)
         elif planned in ['multi', 'singular']:
             idx.append(find_index(dim_coord, selection))
     return tuple(idx)

--- a/borsar/cluster/utils.py
+++ b/borsar/cluster/utils.py
@@ -349,6 +349,7 @@ def _aggregate_cluster(clst, cluster_idx, ignore_dims=None,
 def _label_from_cluster(clst, clst_mask):
     '''Get pysurfer label from cluster mask.'''
     import mne
+
     clst.stc.data[:, 0] = clst_mask
     labels_l, labels_r = mne.stc_to_label(
         clst.stc, src=clst.src, subjects_dir=clst.subjects_dir, smooth=True)

--- a/borsar/cluster/utils.py
+++ b/borsar/cluster/utils.py
@@ -569,6 +569,68 @@ def _index_from_dim(dimnames, dimcoords, **kwargs):
     return tuple(idx)
 
 
+# TODO: add _is_spatial_dim
+# TODO: add errors
+def _prepare_dimindex_plan(dimnames, **kwargs):
+    n_dims = len(dimnames)
+    specified = [dim in kwargs for dim in dimnames]
+    plan =(None,) * n_dims
+    if not any(specified):
+        return plan, kwargs
+
+    for idx in np.where(specified)[0]:
+        dimindex = kwargs[dimnames[idx]]
+
+        if isinstance(dimindex, tuple):
+            if len(dimindex) == 2:
+                plan[idx] = 'range'
+            else:
+                msg = 'TEMP!'
+                raise ValueError(msg)
+        elif isinstance(dimindex, Integral):
+            plan[idx] = 'singular'
+        elif isinstance(dimindex, (list, np.ndarray)):
+            # squeeze array?
+            numel = len(dimindex)
+            if numel == 0:
+                # TODO - what do we do with empty list?
+                msg = 'TEMP!'
+                raise ValueError(msg)
+            elif numel == 1:
+                plan[idx] = 'singular'
+                kwargs[dimnames[idx]] = dimindex[0]
+            else:
+                plan[idx] = 'multi'
+        elif isinstance(dimindex, str):
+            pat = r'[0-9]{1,3}(\.[0-9]*)?%( vol)?'
+            match = re.fullmatch(pat, dimindex)
+            if match is not None:
+                plan[idx] = 'volume'
+                value = float(dimindex.replace('vol', '').replace(' ', '')
+                              .replace('%', ''))
+                if value > 100. or value < 0.:
+                    raise ValueError('The percentage value has to be >= '
+                                     '0 and <= 100.')
+                kwargs[dimnames[idx]] = value
+            else:
+                # TODO: could be a channel name
+                if _is_spatial_dim(dimnames[idx]):
+                    plan[idx] = 'spatial name'
+        elif isinstance(dimindex, slice):
+            if dimindex == slice(None):
+                # "take everyting"
+                plan[idx] = 'full'
+            else:
+                # first it will be ValueError
+                msg = 'TEMP!'
+                raise ValueError(msg)
+        else:
+            msg = 'TEMP!'
+            raise TypeError(msg)
+
+        # LATER: check multi for channel/vertex indices or names
+
+
 def _clean_up_indices(idx):
     '''Turn multiple fancy indexers into what is needed with ``np._ix``.'''
     n_indices = len(idx)

--- a/borsar/cluster/utils.py
+++ b/borsar/cluster/utils.py
@@ -7,6 +7,9 @@ from ..stats import format_pvalue
 from ..channels import find_channels
 
 
+SPATIAL_DIMS = ['chan', 'vert']
+
+
 # FIXME - currently the reading of neighbours seems to be a bit
 #         messy. They should be read into the same format, either
 #         FieldTrip struct (for a starter) or a new class Adjacency
@@ -192,7 +195,7 @@ def _get_clim(data, vmin=None, vmax=None, pysurfer=False):
 def _handle_dims(clst, dims):
     '''Find indices of dimension names.'''
     if dims is None:
-        if clst.dimnames[0] in ['chan', 'vert']:
+        if _is_spatial_dim(clst.dimnames[0]):
             return [0]
         else:
             n_dims = len(clst.dimnames)
@@ -317,7 +320,7 @@ def _aggregate_cluster(clst, cluster_idx, ignore_dims=None,
                             or ix in dim_idx))
 
         # reduce spatial if present, not in dim_idx and list / array
-        if (0 not in reduce_axes and clst.dimnames[0] in ['chan', 'vert']
+        if (0 not in reduce_axes and _is_spatial_dim(clst.dimnames[0])
             and 0 not in dim_idx and isinstance(idx[0], (list, np.ndarray))):
             reduce_axes = (0, ) + reduce_axes
 
@@ -541,7 +544,7 @@ def _index_from_dim(dimnames, dimcoords, **kwargs):
         elif isinstance(selection, list) or (isinstance(selection, np.ndarray)
                                              and selection.ndim == 1):
             # special-case spatial dim
-            if dname in ['chan', 'vert']:
+            if _is_spatial_dim(dname):
                 # find dtype of list/array
                 from numbers import Integral
                 is_int = isinstance(selection[0], Integral)
@@ -569,8 +572,10 @@ def _index_from_dim(dimnames, dimcoords, **kwargs):
     return tuple(idx)
 
 
-# TODO: add _is_spatial_dim
-# TODO: add errors
+def _is_spatial_dim(dimname):
+    return dimname in SPATIAL_DIMS
+
+
 # throw error when kwarg not in dimnames?
 def _prepare_dimindex_plan(dimnames, **kwargs):
     '''Prepare indexing plan.

--- a/borsar/cluster/utils.py
+++ b/borsar/cluster/utils.py
@@ -235,7 +235,7 @@ def _find_mass_index(clst, cluster_idx, plan, kwargs, idx):
 
     # update plan for dropped dimensions
     if stat_sel.ndim < n_dims:
-        to_idx = [ix for ix in range(n_dims) if not plan[ix] == 'singular']
+        to_idx = [ix for ix in range(n_dims) if not 'singular' in plan[ix]]
         this_plan = [plan[ix] for ix in to_idx]
     else:
         this_plan = plan
@@ -597,22 +597,22 @@ def _index_from_dim(dimnames, dimcoords, plan, **kwargs):
     ([1, 3], slice(9, 15, None))
     '''
     idx = list()
-    for dname, dcoord, planned in zip(dimnames, dimcoords, plan):
+    for dim_name, dim_coord, planned in zip(dimnames, dimcoords, plan):
         # ignore dimensions that were not mentioned
         if planned is None or planned in ['mass', 'volume']:
             idx.append(slice(None))
             continue
-        selection = kwargs.pop(dname)
+        selection = kwargs.pop(dim_name)
 
         # find range or specific point-indices
         if planned == 'range':
-            idx.append(find_range(dcoord, selection))
-        elif planned == 'spatial_idx':
+            idx.append(find_range(dim_coord, selection))
+        elif planned in ['spatial_idx', 'spatial_singular']:
             idx.append(selection)
         elif 'spatial_name' in planned:
             raise NotImplementedError('Sorry, not yet.')
         elif planned in ['multi', 'singular']:
-            idx.append(find_index(dcoord, selection))
+            idx.append(find_index(dim_coord, selection))
     return tuple(idx)
 
 
@@ -717,7 +717,7 @@ def _check_singular_index(dimindex, dimname, msg_notfound, msg_spatial):
         if _is_spatial_dim(dimname):
             if isinstance(dimindex, float):
                 raise TypeError(msg_spatial.format(dimindex))
-            return 'spatial_idx', val
+            return 'spatial_singular', val
         else:
             return 'singular', val
     elif isinstance(dimindex, str):

--- a/borsar/cluster/utils.py
+++ b/borsar/cluster/utils.py
@@ -580,11 +580,18 @@ def _is_spatial_dim(dimname):
 def _prepare_dimindex_plan(dimnames, **kwargs):
     '''Prepare indexing plan.
 
-    The plan is a list ...
+    The plan is a list of str where each string informs about detected
+    indexing type/intent for respective dimension.
     '''
+    import re
+    from numbers import Integral
+
+    msg_template = ('Could not understand {}.\nAllowed indexers are: int, str,'
+                    ' list of int, list of str, tuple.')
+
     n_dims = len(dimnames)
     specified = [dim in kwargs for dim in dimnames]
-    plan = {dim: None for dim in dimnames}
+    plan = [None] * n_dims
     if not any(specified):
         return plan, kwargs
 
@@ -596,14 +603,14 @@ def _prepare_dimindex_plan(dimnames, **kwargs):
             # tuple -> range
             # --------------
             if len(dimindex) == 2:
-                plan[this_name] = 'range'
+                plan[idx] = 'range'
             else:
                 msg = ('Indexing with a tuple means specifying a range: '
                        '(from, to). For this reason the tuple has to be of '
                        'length 2.')
                 raise ValueError(msg)
         elif isinstance(dimindex, Integral):
-            plan[this_name] = 'singular'
+            plan[idx] = 'singular'
         elif isinstance(dimindex, (list, np.ndarray)):
             # list or array
             # -------------
@@ -613,39 +620,50 @@ def _prepare_dimindex_plan(dimnames, **kwargs):
                 msg = 'If indexing with a list, the list has to be non-empty.'
                 raise ValueError(msg)
             elif numel == 1:
-                plan[this_name] = 'singular'
+                plan[idx] = 'singular'
                 kwargs[this_name] = dimindex[0]
             else:
-                plan[this_name] = 'multi'
+                if all([isinstance(x, Integral) for x in dimindex]):
+                    plan[idx] = 'multi'
+                elif _is_spatial_dim(this_name):
+                    plan[idx] = 'spatial_names'
+                else:
+                    raise TypeError(msg_template.format(dimindex))
+
         elif isinstance(dimindex, str):
-            pat = r'[0-9]{1,3}(\.[0-9]*)?%( vol)?'
-            match = re.fullmatch(pat, dimindex)
+            pat = r'([0-9]{1,3}(\.[0-9]*)?)(%)( mass)?( vol)?'
+            match = re.match(pat, dimindex)
             if match is not None:
-                plan[this_name] = 'volume'
-                value = float(dimindex.replace('vol', '').replace(' ', '')
-                              .replace('%', ''))
+                parts = match.groups()
+                plan[idx] = 'volume' if parts[-1] is not None else 'mass'
+                value = float(parts[0])
                 if value > 100. or value < 0.:
                     raise ValueError('The percentage value has to be >= '
                                      '0 and <= 100.')
                 kwargs[this_name] = value
             else:
-                # TODO: could be a channel name
+                # TODO: could be a channel \ label name
                 if _is_spatial_dim(this_name):
-                    plan[idx] = 'spatial_names'
-        elif isinstance(dimindex, slice):
-            if dimindex == slice(None):
-                # "take everyting"
-                plan[idx] = 'full'
-            else:
-                # first it will be ValueError
-                msg = 'TEMP!'
-                raise ValueError(msg)
-        else:
-            msg = 'TEMP!'
-            raise TypeError(msg)
+                    plan[idx] = 'spatial_name'
+                else:
+                    raise ValueError('Str indexer has to be either a channel'
+                                     ' name or volume/mass percentage (for '
+                                     'example "50% vol")')
 
-        # LATER: check multi for channel/vertex indices or names
-        return plan, kwargs
+        # not sure about slices now
+        # elif isinstance(dimindex, slice):
+        #     if dimindex == slice(None):
+        #         # "take everyting"
+        #         plan[idx] = 'full'
+        #     else:
+        #         # first it will be ValueError
+        #         msg = 'TEMP!'
+        #         raise ValueError(msg)
+        else:
+            raise TypeError(msg_template.format(dimindex))
+
+    # LATER: check multi for channel/vertex indices or names
+    return plan, kwargs
 
 
 def _clean_up_indices(idx):

--- a/borsar/cluster/utils.py
+++ b/borsar/cluster/utils.py
@@ -1,6 +1,9 @@
 import random
+import re
+
 import numpy as np
 from scipy import sparse
+from numbers import Integral, Real
 
 from ..utils import group_mask, find_range, find_index
 from ..stats import format_pvalue
@@ -493,10 +496,10 @@ def _ensure_correct_info(clst):
 
 
 # - [ ] add special functions for handling dims like vert or chan
-def _index_from_dim(dimnames, dimcoords, **kwargs):
+def _index_from_dim(dimnames, dimcoords, plan, **kwargs):
     '''
-    Find axis indices or slices given dimnames, dimcoords and dimname keyword
-    arguments of ``dimname=value`` form.
+    Find axis indices or slices given dimnames, dimcoords, dimindex plan and
+    dimname keyword arguments of ``dimname=value`` form.
 
     Parameters
     ----------
@@ -507,6 +510,8 @@ def _index_from_dim(dimnames, dimcoords, **kwargs):
     dimcoords : list of arrays
         List of arrays, where each array contains coordinates (labels) for
         consecutive elements in corresponding dimension.
+    plan : list
+        Indexing plan created by ``_prepare_dimindex_plan``.
     **kwargs : additional keywords
         Keywords referring to dimension names. Value of these keyword has to be
         either:
@@ -529,46 +534,23 @@ def _index_from_dim(dimnames, dimcoords, **kwargs):
     >>> _index_from_dim(dimnames, dimcoords, freq=[9, 11], time=(0.25, 0.5))
     ([1, 3], slice(9, 15, None))
     '''
-
     idx = list()
-    for dname, dcoord in zip(dimnames, dimcoords):
+    for dname, dcoord, planned in zip(dimnames, dimcoords, plan):
         # ignore dimensions that were not mentioned
-        if dname not in kwargs:
+        if planned is None or planned in ['mass', 'vol']:
             idx.append(slice(None))
             continue
         selection = kwargs.pop(dname)
 
         # find range or specific point-indices
-        if isinstance(selection, tuple) and len(selection) == 2:
+        if planned == 'range':
             idx.append(find_range(dcoord, selection))
-        elif isinstance(selection, list) or (isinstance(selection, np.ndarray)
-                                             and selection.ndim == 1):
-            # special-case spatial dim
-            if _is_spatial_dim(dname):
-                # find dtype of list/array
-                from numbers import Integral
-                is_int = isinstance(selection[0], Integral)
-
-                if is_int:
-                    # 1) channel indices
-                    idx.append(selection)
-                else:
-                    # 2) channel names? (labels?)
-                    if (dname == 'chan' and isinstance(selection, list)
-                        and isinstance(selection[0], str)):
-                        # find channel indices
-                        raise NotImplementedError('Sorry, not yet.')
-                    else:
-                        raise ValueError('Spatial dimension indexer has to '
-                                         'be either a list/array or int or '
-                                         'a list of channel names.')
-
-            else:
-                idx.append(find_index(dcoord, selection))
-        else:
-            sel_type = type(selection)
-            raise TypeError('Keyword arguments has to have tuple of length 2 '
-                            'list or 1d array, got {}.'.format(sel_type))
+        elif planned == 'spatial_idx':
+            idx.append(selection)
+        elif 'spatial_name' in planned:
+            raise NotImplementedError('Sorry, not yet.')
+        elif planned in ['multi', 'singular']:
+            idx.append(find_index(dcoord, selection))
     return tuple(idx)
 
 
@@ -576,18 +558,40 @@ def _is_spatial_dim(dimname):
     return dimname in SPATIAL_DIMS
 
 
-# throw error when kwarg not in dimnames?
+# - [ ] throw error when kwarg not in dimnames?
+# - [ ] original code had some basic support for slices, but it does not seem
+#       necessary now.
+# elif isinstance(dimindex, slice):
+#     if dimindex == slice(None):
+#         # "take everyting"
+#         plan[idx] = 'full'
 def _prepare_dimindex_plan(dimnames, **kwargs):
     '''Prepare indexing plan.
 
     The plan is a list of str where each string informs about detected
     indexing type/intent for respective dimension.
-    '''
-    import re
-    from numbers import Integral, Real
 
-    msg_template = ('Could not understand {}.\nAllowed indexers are: int, str,'
+    Possible plans:
+    * singular      - one simple index in data label coordinates, have to be
+                      translated
+    * range         - tuple of indices in data label coordinates, have to be
+                      translated to a slice
+    * multi         - list / array of indices in data label coordinates, have
+                      to be translated
+    * spatial_idx   - index/indices that are already in the right coordinates,
+                      no need for translation
+    * spatial_name  - channel/label name, have to be translated in a special way
+    * spatial_names - channel/label names, have to be translated in a special
+                      way
+    * volume
+    * mass
+    '''
+    msg_notfound = ('Could not understand {}.\nAllowed indexers are: int, str,'
                     ' list of int, list of str, tuple.')
+    msg_spatial = ('Indexing spatial dimension is allowed only with int, str, '
+                   'list/array of int or list/array of str. Got {}.')
+    msg_nonspat = ('Indexing non-spatial dimensions is allowed only with int, '
+                   'float, list/array of int or list/array of float. Got {}.')
 
     n_dims = len(dimnames)
     specified = [dim in kwargs for dim in dimnames]
@@ -596,8 +600,8 @@ def _prepare_dimindex_plan(dimnames, **kwargs):
         return plan, kwargs
 
     for idx in np.where(specified)[0]:
-        this_name = dimnames[idx]
-        dimindex = kwargs[this_name]
+        this_dim_name = dimnames[idx]
+        dimindex = kwargs[this_dim_name]
 
         if isinstance(dimindex, tuple):
             # tuple -> range
@@ -618,64 +622,64 @@ def _prepare_dimindex_plan(dimnames, **kwargs):
                 msg = 'If indexing with a list, the list has to be non-empty.'
                 raise ValueError(msg)
             elif numel == 1:
+                # CONSIDER - not sure if this is the right thing to do, in
+                #            numpy this would mean select, but not drop the dim
                 dimindex = dimindex[0]
-                kwargs[this_name] = dimindex
+                plan[idx], kwargs[this_dim_name] = _check_singular_index(
+                    dimindex, this_dim_name, msg_notfound, msg_spatial)
             else:
-                if _is_spatial_dim(this_name):
+                if _is_spatial_dim(this_dim_name):
                     if all([isinstance(x, Integral) for x in dimindex]):
                         plan[idx] = 'spatial_idx'
                     elif all([isinstance(x, str) for x in dimindex]):
                         plan[idx] = 'spatial_names'
                     else:
-                        msg = ('Indexing spatial dimension is allowed only '
-                               'with int, str, list/array of int or list/array'
-                               ' of str. Got {}.')
-                        raise TypeError(msg.format(dimindex))
+                        raise TypeError(msg_spatial.format(dimindex))
                 else:
                     if all([isinstance(x, Real) for x in dimindex]):
                         plan[idx] = 'multi'
                     else:
-                        msg = ('Indexing non-spatial dimensions is allowed '
-                               'only with int, float, list/array of int or '
-                               'list/array of float. Got {}.')
-                        raise TypeError(msg.format(dimindex))
-        elif isinstance(dimindex, (Integral, float)):
-            plan[idx] = 'singular'
-        elif isinstance(dimindex, str):
-            pat = r'([0-9]{1,3}(\.[0-9]*)?)(%)( mass)?( vol)?'
-            match = re.match(pat, dimindex)
-            if match is not None:
-                parts = match.groups()
-                plan[idx] = 'volume' if parts[-1] is not None else 'mass'
-                value = float(parts[0])
-                if value > 100. or value < 0.:
-                    msg = ('The mass/volume percentage indexer has to be >= 0'
-                           ' and <= 100, got {}.').format(dimindex)
-                    raise ValueError(msg)
-                kwargs[this_name] = value / 100
-            else:
-                # TODO: could be a channel \ label name
-                if _is_spatial_dim(this_name):
-                    plan[idx] = 'spatial_name'
-                else:
-                    raise ValueError('Str indexer has to be either a channel'
-                                     ' name or volume/mass percentage (for '
-                                     'example "50% vol")')
-
-        # not sure about slices now
-        # elif isinstance(dimindex, slice):
-        #     if dimindex == slice(None):
-        #         # "take everyting"
-        #         plan[idx] = 'full'
-        #     else:
-        #         # first it will be ValueError
-        #         msg = 'TEMP!'
-        #         raise ValueError(msg)
+                        raise TypeError(msg_nonspat.format(dimindex))
         else:
-            raise TypeError(msg_template.format(dimindex))
+            plan[idx], kwargs[this_dim_name] = _check_singular_index(
+                dimindex, this_dim_name, msg_notfound, msg_spatial)
 
     # LATER: check multi for channel/vertex indices or names
     return plan, kwargs
+
+
+def _check_singular_index(dimindex, dimname, msg_notfound, msg_spatial):
+    val = dimindex
+    if isinstance(dimindex, (Integral, float)):
+        if _is_spatial_dim(dimname):
+            if isinstance(dimindex, float):
+                raise TypeError(msg_spatial.format(dimindex))
+            return 'spatial_idx', val
+        else:
+            return 'singular', val
+    elif isinstance(dimindex, str):
+        pat = r'([0-9]{1,3}(\.[0-9]*)?)(%)( mass)?( vol)?'
+        match = re.match(pat, dimindex)
+        if match is not None:
+            parts = match.groups()
+            plan = 'volume' if parts[-1] is not None else 'mass'
+            value = float(parts[0])
+            if value > 100. or value < 0.:
+                msg = ('The mass/volume percentage indexer has to be >= 0'
+                       ' and <= 100, got {}.').format(dimindex)
+                raise ValueError(msg)
+            val = value / 100
+            return plan, val
+        else:
+            # TODO: could be a channel \ label name
+            if _is_spatial_dim(dimname):
+                return 'spatial_name', val
+            else:
+                raise ValueError('String indexer has to be either a channel'
+                                 ' name or volume/mass percentage (for '
+                                 'example "50% vol"). Got {}'.format(dimindex))
+    else:
+        raise TypeError(msg_notfound.format(dimindex))
 
 
 def _clean_up_indices(idx):

--- a/borsar/cluster/viz.py
+++ b/borsar/cluster/viz.py
@@ -176,7 +176,7 @@ def plot_cluster_chan(clst, cluster_idx=None, dims=None, vmin=None, vmax=None,
 
     # consider dims
     dim_idx = _handle_dims(clst, dims)
-    dims = [clst.dimnames[ix] for ix in dim_idx]
+    dims = [clst.dimnames[ix] for ix in dim_idx] # because chan can be added
 
     # TODO - aggregate should work when no clusters
     # get and aggregate cluster mask and cluster stat

--- a/borsar/cluster/viz.py
+++ b/borsar/cluster/viz.py
@@ -176,7 +176,7 @@ def plot_cluster_chan(clst, cluster_idx=None, dims=None, vmin=None, vmax=None,
 
     # consider dims
     dim_idx = _handle_dims(clst, dims)
-    dims = [clst.dimnames[ix] for ix in dim_idx] # because chan can be added
+    dims = [clst.dimnames[ix] for ix in dim_idx]  # because chan can be added
 
     # TODO - aggregate should work when no clusters
     # get and aggregate cluster mask and cluster stat

--- a/borsar/cluster/viz.py
+++ b/borsar/cluster/viz.py
@@ -55,8 +55,8 @@ def plot_cluster_contribution(clst, dims, picks=None, axis=None, **kwargs):
     # ----
     picks = list(range(n_clusters)) if picks is None else picks
     ax = plot_cluster_chan(clst, picks, dims=dims, plot_contribution=True,
-                            retain_mass=1., axis=axis, cmap='viridis',
-                            **kwargs)
+                           retain_mass=1., axis=axis, cmap='viridis',
+                           **kwargs)
 
     # create "intensity" label
     # ------------------------
@@ -248,10 +248,10 @@ def plot_cluster_chan(clst, cluster_idx=None, dims=None, vmin=None, vmax=None,
             if labeldims:
                 _label_topos(clst, topo, dim_kwargs, idx)
 
-            if 'axes' not in plotfun_kwargs:
+            # if 'axes' not in plotfun_kwargs:
                 # we created the axes so we can reposition them for better
                 # topo titles visibility
-                _move_axes_to(topo.axes, y=0.05)
+                # _move_axes_to(topo.axes, y=0.05)
 
             return topo
         else:

--- a/borsar/freq.py
+++ b/borsar/freq.py
@@ -361,15 +361,6 @@ class PSD(*mixins):
         # create list of psd's (one element for each channel type)
         psd_list = list()
         for picks in picks_list:
-<<<<<<< HEAD
-            psd_list.append(inst.data[picks])
-
-        args = [inst, fig, inst.freqs, psd_list, picks_list, titles_list,
-                units_list, scalings_list, ax_list, make_label, color,
-                area_mode, area_alpha, dB, estimate, average, spatial_colors,
-                xscale, line_alpha]
-        args += [sphere, xlabels_list]
-=======
             this_psd = self.data[..., picks, rng]
             if self._has_epochs:
                 this_psd = this_psd.mean(axis=0)
@@ -387,7 +378,6 @@ class PSD(*mixins):
                             make_label, color, area_mode, area_alpha, dB,
                             estimate, average, spatial_colors, xscale,
                             line_alpha)
->>>>>>> ebbd887 (FIX: new mne compat in freq.py)
 
         fig = _plot_psd(*args)
         plt_show(show)

--- a/borsar/freq.py
+++ b/borsar/freq.py
@@ -323,35 +323,17 @@ class PSD(*mixins):
         # set up default vars
         from packaging import version
         mne_version = version.parse(mne.__version__)
-        has_new_mne = mne_version >= version.parse('0.22.0')
-
-        if has_new_mne:
+        test_versions = ['0.23.0', '0.20.0']
+        has_new_mne = [mne_version >= version.parse(ver)
+                       for ver in test_versions]
+        if has_new_mne[0]:
             from mne.defaults import _handle_default
-            from mne.io.pick import _picks_to_idx
-            try:
-                from mne.viz._figure import _split_picks_by_type
-            except ImportError:
-                # this was changed around 1.0 mne version
-                from mne.viz._mpl_figure import _split_picks_by_type
-
-            if ax is None:
-                import matplotlib.pyplot as plt
-                fig, ax = plt.subplots()
-            else:
-                fig = ax.figure
-            ax_list = [ax]
-
+            from mne.viz._figure import _line_figure, _split_picks_by_type
+            fig, axes = _line_figure(self, ax, picks)
             units = _handle_default('units', None)
-            picks = _picks_to_idx(self.info, picks)
-            titles = _handle_default('titles', None)
-            scalings = _handle_default('scalings', None)
-
-            make_label = len(ax_list) == len(fig.axes)
-            xlabels_list = [False] * (len(ax_list) - 1) + [True]
             (picks_list, units_list, scalings_list, titles_list
              ) = _split_picks_by_type(self, picks, units, scalings, titles)
-        else:
-            from mne.viz.utils import _set_psd_plot_params
+        elif has_new_mne[1]:
             fig, picks_list, titles_list, units_list, scalings_list, \
                 ax_list, make_label, xlabels_list = _set_psd_plot_params(
                     self.info, proj, picks, ax, area_mode)

--- a/borsar/freq.py
+++ b/borsar/freq.py
@@ -326,11 +326,22 @@ class PSD(*mixins):
         test_versions = ['0.23.0', '0.20.0']
         has_new_mne = [mne_version >= version.parse(ver)
                        for ver in test_versions]
+        if not has_new_mne[0]:
+            from mne.viz.utils import _set_psd_plot_params
         if has_new_mne[0]:
+            from mne.io.pick import _picks_to_idx
             from mne.defaults import _handle_default
             from mne.viz._figure import _line_figure, _split_picks_by_type
-            fig, axes = _line_figure(self, ax, picks)
+
+            fig, ax_list = _line_figure(self, ax, picks)
+            make_label = len(ax_list) == len(fig.axes)
+            xlabels_list = [False] * (len(ax_list) - 1) + [True]
+
             units = _handle_default('units', None)
+            titles = _handle_default('titles')
+            scalings = _handle_default('scalings')
+            picks = _picks_to_idx(self.info, picks, exclude=self.info['bads'])
+
             (picks_list, units_list, scalings_list, titles_list
              ) = _split_picks_by_type(self, picks, units, scalings, titles)
         elif has_new_mne[1]:
@@ -350,6 +361,7 @@ class PSD(*mixins):
         # create list of psd's (one element for each channel type)
         psd_list = list()
         for picks in picks_list:
+<<<<<<< HEAD
             psd_list.append(inst.data[picks])
 
         args = [inst, fig, inst.freqs, psd_list, picks_list, titles_list,
@@ -357,6 +369,25 @@ class PSD(*mixins):
                 area_mode, area_alpha, dB, estimate, average, spatial_colors,
                 xscale, line_alpha]
         args += [sphere, xlabels_list]
+=======
+            this_psd = self.data[..., picks, rng]
+            if self._has_epochs:
+                this_psd = this_psd.mean(axis=0)
+            psd_list.append(this_psd)
+
+        if any(has_new_mne):
+            fig = _plot_psd(self, fig, self.freqs[rng], psd_list, picks_list,
+                            titles_list, units_list, scalings_list, ax_list,
+                            make_label, color, area_mode, area_alpha, dB,
+                            estimate, average, spatial_colors, xscale,
+                            line_alpha, sphere, xlabels_list)
+        else:
+            fig = _plot_psd(self, fig, self.freqs[rng], psd_list, picks_list,
+                            titles_list, units_list, scalings_list, ax_list,
+                            make_label, color, area_mode, area_alpha, dB,
+                            estimate, average, spatial_colors, xscale,
+                            line_alpha)
+>>>>>>> ebbd887 (FIX: new mne compat in freq.py)
 
         fig = _plot_psd(*args)
         plt_show(show)

--- a/borsar/freq.py
+++ b/borsar/freq.py
@@ -175,7 +175,7 @@ def compute_psd(inst, tmin=None, tmax=None, winlen=None, step=None, padto=None,
     from mne.time_frequency import psd_welch
     try:
         from mne.selection import pick_types
-    except ImportError:
+    except ModuleNotFoundError:
         from mne.pick import pick_types
 
     if tmin is None:

--- a/borsar/freq.py
+++ b/borsar/freq.py
@@ -173,6 +173,10 @@ def compute_psd(inst, tmin=None, tmax=None, winlen=None, step=None, padto=None,
         PowerSpectralDensity (PSD) object.
     """
     from mne.time_frequency import psd_welch
+    try:
+        from mne.selection import pick_types
+    except ImportError:
+        from mne.pick import pick_types
 
     if tmin is None:
         tmin = inst.times[0]
@@ -219,6 +223,7 @@ def compute_psd(inst, tmin=None, tmax=None, winlen=None, step=None, padto=None,
                         'formats, got {}'.format(type(inst)))
 
     # construct PSD object
+    # TODO: see if this is necessary on mne >= 0.20
     try:
         from mne.selection import pick_types
     except ModuleNotFoundError:

--- a/borsar/freq.py
+++ b/borsar/freq.py
@@ -223,7 +223,8 @@ def compute_psd(inst, tmin=None, tmax=None, winlen=None, step=None, padto=None,
                         'formats, got {}'.format(type(inst)))
 
     # construct PSD object
-    # TODO: see if this is necessary on mne >= 0.20
+    # TODO: check in which mne version pick_types was relocated
+    #       so that this can be removed when dropping support of that version
     try:
         from mne.selection import pick_types
     except ModuleNotFoundError:

--- a/borsar/freq.py
+++ b/borsar/freq.py
@@ -176,7 +176,7 @@ def compute_psd(inst, tmin=None, tmax=None, winlen=None, step=None, padto=None,
     try:
         from mne.selection import pick_types
     except ModuleNotFoundError:
-        from mne.pick import pick_types
+        from mne.io.pick import pick_types
 
     if tmin is None:
         tmin = inst.times[0]

--- a/borsar/stats.py
+++ b/borsar/stats.py
@@ -33,7 +33,7 @@ def compute_regression_t(data, preds, return_p=False):
     df = n_obs - n_preds
     original_shape = data.shape
     data = data.reshape((original_shape[0], np.prod(original_shape[1:])))
-    coefs, _, _, _ = np.linalg.lstsq(preds, data)
+    coefs, _, _, _ = np.linalg.lstsq(preds, data, rcond=None)
     prediction = (preds[:, :, np.newaxis] * coefs[np.newaxis, :]
                   ).sum(axis=1)
     MSE = (((data - prediction) ** 2).sum(axis=0, keepdims=True) / df)

--- a/borsar/tests/test_utils.py
+++ b/borsar/tests/test_utils.py
@@ -1,5 +1,6 @@
 import os
 import os.path as op
+import warnings
 from warnings import warn
 
 import numpy as np
@@ -183,6 +184,7 @@ def test_silent_mne():
     has_new_mne = version.parse(mne.__version__) >= version.parse('0.19.0')
     raw = create_fake_raw(n_channels=2, n_samples=10, sfreq=10.)
     pos = np.random.random((2, 3))
+    data = np.random.rand(25) - 0.5
 
     if has_new_mne:
         ch_pos = {'a': pos[0, :], 'b': pos[1, :]}
@@ -191,29 +193,28 @@ def test_silent_mne():
         mntg = mne.channels.Montage(pos, ['a', 'b'], 'eeg', 'fake')
     raw.set_montage(mntg)
 
-    # adding new reference channel without position gives a warning:
+    # adding new reference channel without position used to give a warning
+    # (but it no longer seems to?)
+    # so we pick something a bit random from mne that raises warnings
     with pytest.warns(Warning):
-        mne.add_reference_channels(raw.copy(), ['nose'])
+        mne.viz.utils._setup_vmin_vmax(data, vmin=None, vmax=5., norm=True)
 
     # ... but not when using silent_mne() context manager:
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         with silent_mne():
-            mne.add_reference_channels(raw.copy(), ['nose'])
+            mne.viz.utils._setup_vmin_vmax(data, vmin=None, vmax=5., norm=True)
 
-    # new numpy (>= 1.20) raises warnings on older mne (<= 0.20)
-    mne_version = version.parse(mne.__version__)
-
-    if mne_version >= version.parse('0.21'):
-        assert len(record) == 0
+    # new numpy (>= 1.20) raised warnings on older mne (<= 0.20)
+    # but now we don't support mne 0.20, so we are good here
 
     # with `full_silence` no warnings are raised
     # (irrespective of mne and numpy)
-    with pytest.warns(None) as record:
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
         with silent_mne(full_silence=True):
-            mne.add_reference_channels(raw.copy(), ['nose'])
+            mne.viz.utils._setup_vmin_vmax(data, vmin=None, vmax=5., norm=True)
             warn('annoying warning!', DeprecationWarning)
-
-    assert len(record) == 0
 
 
 def test_group():

--- a/borsar/tests/test_viz.py
+++ b/borsar/tests/test_viz.py
@@ -195,6 +195,38 @@ def test_topo_simulated_data():
     # plt.scatter(xy_pos[:, 0], xy_pos[:, 1], color='k')
 
 
+def test_topo_grid():
+    "Test that nrows and ncols are respected by Topo."
+    pos = (np.random.rand(10, 2) - 0.5) * 0.33
+    data = np.random.rand(10, 8)
+
+    def test_grid_shape(topo, nrows, ncols):
+        gridspec = topo.axes[0].get_gridspec()
+        assert gridspec.nrows == nrows
+        assert gridspec.ncols == ncols
+
+    topo = Topo(data, pos)
+    test_grid_shape(topo, 2, 6)
+    plt.close(topo.axes[0].figure)
+
+    topo = Topo(data, pos, nrows=3)
+    test_grid_shape(topo, 3, 3)
+    plt.close(topo.axes[0].figure)
+
+    topo = Topo(data, pos, ncols=2)
+    test_grid_shape(topo, 4, 2)
+    plt.close(topo.axes[0].figure)
+
+    topo = Topo(data, pos, nrows=5, ncols=5)
+    test_grid_shape(topo, 5, 5)
+    plt.close(topo.axes[0].figure)
+
+    data = np.random.rand(10, 40)
+    topo = Topo(data, pos)
+    test_grid_shape(topo, 6, 7)
+    plt.close(topo.axes[0].figure)
+
+
 def test_heatmap():
     data = np.random.random((5, 6))
     x = np.linspace(10, 12, num=6)

--- a/borsar/viz.py
+++ b/borsar/viz.py
@@ -23,10 +23,21 @@ class Topo(object):
     info : mne Info instance
         Info object containing channel positions.
     axes : matplotlib Axes, optional
-        Axes to plot in. Creates new by default. The axes handle is later
-        available in ``.axes`` attribute. If ``values`` is two dimensional
-        then ``axes`` has to be a list of matplotlib Axes of length equal
-        to the size of the second dimension (``values.shape[1]``).
+        Axes to plot in. New axes are created by default. The axes handle is
+        later available in ``.axes`` attribute. If ``values`` is two
+        dimensional then ``axes`` has to be a list of matplotlib Axes of
+        length equal to the size of the second dimension
+        (``values.shape[1]``).
+    nrows : int | 'auto'
+        If ``axes`` are not defined and multiple topographies are plotted (see
+        ``values`` argument), ``nrows`` controls the number of rows in the
+        supblot matrix. ``nrows='auto'`` (default) automatically tries to
+        figure best number of rows.
+    ncols : int | 'auto'
+        If ``axes`` are not defined and multiple topographies are plotted (see
+        ``values`` argument), ``ncols`` controls the number of columns in the
+        supblot matrix. ``ncols='auto'`` (default) automatically tries to
+        figure best number of columns.
     **kwargs : any additional keyword arguments
         Additional keyword arguments are passed to `mne.viz.plot_topomap`.
 
@@ -45,11 +56,13 @@ class Topo(object):
     topo.mark_channels([4, 5, 6], markerfacecolor='r', markersize=12)
     '''
 
-    def __init__(self, values, info, side=None, **kwargs):
+    def __init__(self, values, info, *, nrows='auto', ncols='auto', **kwargs):
         from ._mne_compat import plot_topomap
 
         self.info = info
         self.values = values
+        self.nrows = nrows
+        self.ncols = ncols
 
         # FIXME: should squeezing really be considered?
         self._squeezed = False
@@ -346,14 +359,37 @@ class Topo(object):
         else:
             # no axes passed, create figure and axes
             if self.multi_axes:
-                # create a row of topographies
-                n_per_topo = 2.5
-                fig_size = (n_per_topo * self.n_topos, n_per_topo)
-                fig, axes = plt.subplots(ncols=self.n_topos, figsize=fig_size)
-                self.axes = axes.tolist()
+                _create_topo_layout(self)
             else:
                 fig, axes = plt.subplots()
                 self.axes = [axes]
+
+
+# consider automatic scaling of inch_per_topo when too many topographies
+# (this could also be a size argument)
+def _create_topo_layout(topo, inch_per_topo=2.):
+    # create a rows x columns matrix of topographies
+    if topo.nrows == 'auto' and topo.ncols == 'auto':
+        if (topo.n_topos / 6) <= 4:
+            topo.ncols = 6
+        else:
+            topo.ncols = int(np.ceil(np.sqrt(topo.n_topos)))
+
+    if isinstance(topo.ncols, int) and topo.nrows == 'auto':
+        topo.nrows = int(np.ceil(topo.n_topos / topo.ncols))
+    elif topo.ncols == 'auto' and isinstance(topo.nrows, int):
+        topo.ncols = int(np.ceil(topo.n_topos / topo.nrows))
+
+    gridspec_kw = {'left': 0.05, 'bottom': 0.02, 'top': 0.9, 'right': 0.95}
+    fig_size = (inch_per_topo * topo.ncols, inch_per_topo * topo.nrows * 0.95)
+    fig, axes = plt.subplots(ncols=topo.ncols, nrows=topo.nrows,
+                             figsize=fig_size, gridspec_kw=gridspec_kw)
+    topo.axes = axes.ravel().tolist()
+
+    n_empty = (topo.ncols * topo.nrows) - topo.n_topos
+    for _ in range(n_empty):
+        empty_ax = topo.axes.pop(-1)
+        empty_ax.remove()
 
 
 def _extract_topo_channels(ax):

--- a/environment.yml
+++ b/environment.yml
@@ -2,10 +2,10 @@ name: borsar
 channels:
 - defaults
 dependencies:
-- python>=3.8
+- python>=3.10
 - pip
-- mkl=2020.2
-- numpy=1.20.1
+- mkl>=2021.4.0
+- numpy>=1.20.1
 - scipy
 - matplotlib
 - pandas
@@ -14,21 +14,17 @@ dependencies:
 - scikit-image
 - h5py
 # dev/testing libraries:
-- statsmodels
+- statsmodels>=0.13.2
 - pytest
 - pytest-cov
 - psutil
 - numpydoc
 - flake8
 # likely not needed:
-- pillow
-- spyder
-- jupyter
 - joblib
 - pip:
   - mne
   - h5io
-  - neo
   - pydocstyle
   - codespell
   - sphinx_gallery


### PR DESCRIPTION
First step towards simpler and better dimension indexing:
- [x] add function that prepares dimindex plan
- [x] test the function
- [x] use it in `.get_index()` (currently to do exactly the same what this method did)
- [x] check where else it would be useful (cluster plotting and aggregation) - for later PRs
- [x] `.get_index()` should not use `.get_cluster_limits()` internally - this way the `idx` arg could be removed from `get_cluster_limits()`
- [x] make borsar compatible with new mne version
- [x] test `clst.plot(chan=5, time='75%')` 

## TODOs:
- [ ] update docs about `'60%'` (defaulting to mass) and `'60% vol'` (to select by cluster volume)
- [ ] reducing both dimensions for example with `clst.plot(chan=5, time='75%')` when dimnames are `['chan', 'time']` should lead to some kind of error in plotting
- [ ] make `get_cluster_limits` work with % (both mass and vol):
```python
clst.get_cluster_limits(0, time='50%')
```
```python-traceback
Traceback (most recent call last):

  File "C:\Users\mmagn\AppData\Local\Temp\ipykernel_45840\1571919122.py", line 1, in <cell line: 1>
    clst.get_cluster_limits(0, time='50%')

  File "c:\src\borsar\borsar\cluster\obj.py", line 483, in get_cluster_limits
    lims = _get_mass_range(contrib, mass, adjacent=adj)

  File "c:\src\borsar\borsar\cluster\utils.py", line 490, in _get_mass_range
    while current_mass < mass:

TypeError: '<' not supported between instances of 'numpy.ndarray' and 'str'
```