### PR TITLE
1d clustering, allow thresholds defined with permutation tests (permutation ttest for example)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ install:
   - conda install scikit-image
   - pip install codecov tqdm
   - if [ "${MNE_VERSION}" == "current" ]; then
-      pip install mne;
+      pip install mne pooch;
     fi
   - if [ "${MNE_VERSION}" == "0.21" ]; then
       pip install mne==0.21.2;

--- a/borsar/cluster/label.py
+++ b/borsar/cluster/label.py
@@ -282,9 +282,15 @@ def _find_clusters_mne(data, threshold, adjacency, argname, min_adj_ch=0,
 
 def _find_clusters_borsar(data, threshold, adjacency, cluster_fun,
                           min_adj_ch=0, full=True):
+    if isinstance(threshold, list):
+        assert len(threshold) == 2
+        pos_threshold, neg_threshold = threshold
+    else:
+        pos_threshold, neg_threshold = threshold, -threshold
+
     # positive clusters
     # -----------------
-    pos_clusters = cluster_fun(data > threshold, adjacency=adjacency,
+    pos_clusters = cluster_fun(data > pos_threshold, adjacency=adjacency,
                                min_adj_ch=min_adj_ch)
 
     # TODO - consider numba optimization of this part too:
@@ -295,7 +301,7 @@ def _find_clusters_borsar(data, threshold, adjacency, cluster_fun,
 
     # negative clusters
     # -----------------
-    neg_clusters = cluster_fun(data < -threshold, adjacency=adjacency,
+    neg_clusters = cluster_fun(data < neg_threshold, adjacency=adjacency,
                                min_adj_ch=min_adj_ch)
 
     # TODO - consider numba optimization of this part too:

--- a/borsar/cluster/label.py
+++ b/borsar/cluster/label.py
@@ -114,8 +114,10 @@ def _cross_channel_adjacency_3d(clusters, adjacency, min_adj_ch=0):
     return clusters
 
 
-def _cluster_1d_or_2d_no_adj(data):
+def _cluster_1d_or_2d_no_adj(data, adjacency=None, min_adj_ch=0):
     from skimage.measure import label
+    assert adjacency is None
+    assert min_adj_ch == 0
     return label(data, connectivity=1, background=False)
 
 

--- a/borsar/cluster/label.py
+++ b/borsar/cluster/label.py
@@ -288,7 +288,8 @@ def _find_clusters_borsar(data, threshold, adjacency, cluster_fun,
                                min_adj_ch=min_adj_ch)
 
     # TODO - consider numba optimization of this part too:
-    cluster_id = np.unique(pos_clusters)[1:]
+    cluster_id = np.unique(pos_clusters)
+    cluster_id = cluster_id[1:] if 0 in cluster_id else cluster_id
     pos_clusters = [pos_clusters == id for id in cluster_id]
     cluster_stats = [data[clst].sum() for clst in pos_clusters]
 
@@ -298,7 +299,8 @@ def _find_clusters_borsar(data, threshold, adjacency, cluster_fun,
                                min_adj_ch=min_adj_ch)
 
     # TODO - consider numba optimization of this part too:
-    cluster_id = np.unique(neg_clusters)[1:]
+    cluster_id = np.unique(neg_clusters)
+    cluster_id = cluster_id[1:] if 0 in cluster_id else cluster_id
     neg_clusters = [neg_clusters == id for id in cluster_id]
     cluster_stats = np.array(cluster_stats + [data[clst].sum()
                                               for clst in neg_clusters])

--- a/borsar/cluster/utils.py
+++ b/borsar/cluster/utils.py
@@ -67,7 +67,7 @@ def construct_adjacency_matrix(neighbours, ch_names=None, as_sparse=False):
         for ch_idx, chan in enumerate(ch_names):
             ngb_ind = np.where(neighbours['label'] == chan)[0]
 
-            # safty checks:
+            # safety checks:
             if len(ngb_ind) == 0:
                 raise ValueError(('channel {} was not found in neighbours.'
                                   .format(chan)))
@@ -214,7 +214,7 @@ def _handle_dims(clst, dims):
 # TODO:
 # - [~] make sure dimensions are sorted according to ``ignore_dims``
 #       (this is done elsewhere - in plotting now, here it might not matter)
-# - [ ] beware of changing dimension order for some complex "facny index"
+# - [ ] beware of changing dimension order for some complex "fancy index"
 #       operations
 def _aggregate_cluster(clst, cluster_idx, ignore_dims=None,
                        mask_proportion=0.5, retain_mass=0.65, mask_sum=False,

--- a/borsar/utils.py
+++ b/borsar/utils.py
@@ -447,6 +447,7 @@ def download_test_data():
 
     # set up paths
     fname = 'temp_file.zip'
+    destination = op.join(data_dir, fname)
     download_link = ('https://www.dropbox.com/sh/l4scs37524lb3pa/'
                      'AABCak4jORjgridWwHlwjhMHa?dl=1')
 
@@ -457,7 +458,6 @@ def download_test_data():
         pooch.retrieve(url=download_link, known_hash=hash,
                        path=data_dir, fname=fname)
     else:
-        destination = op.join(data_dir, fname)
         _fetch_file(download_link, destination, print_destination=True,
                     resume=True, timeout=30.)
 

--- a/borsar/utils.py
+++ b/borsar/utils.py
@@ -432,7 +432,7 @@ def download_test_data():
     try:
         from mne.utils import _fetch_file
         use_pooch = False
-    except:
+    except ImportError:
         import pooch
         use_pooch = True
 

--- a/borsar/utils.py
+++ b/borsar/utils.py
@@ -316,7 +316,7 @@ def valid_windows(raw, tmin=None, tmax=None, winlen=2., step=1.):
     Returns
     -------
     valid : boolean numpy array
-        Whether the moving widnows overlap with annotations. Consecutive values
+        Whether the moving windows overlap with annotations. Consecutive values
         inform whether consecutive windows overlap with any annotation.
     '''
     # get and select bad annotations
@@ -429,7 +429,12 @@ def _get_test_data_dir():
 def download_test_data():
     '''Download additional test data from dropbox.'''
     import zipfile
-    from mne.utils import _fetch_file
+    try:
+        from mne.utils import _fetch_file
+        use_pooch = False
+    except:
+        import pooch
+        use_pooch = True
 
     # check if test data exist
     data_dir = _get_test_data_dir()
@@ -441,13 +446,20 @@ def download_test_data():
         return
 
     # set up paths
+    fname = 'temp_file.zip'
     download_link = ('https://www.dropbox.com/sh/l4scs37524lb3pa/'
                      'AABCak4jORjgridWwHlwjhMHa?dl=1')
-    destination = op.join(data_dir, 'temp_file.zip')
 
     # download the file
-    _fetch_file(download_link, destination, print_destination=True,
-                resume=True, timeout=30.)
+    if use_pooch:
+        hash = ('98bab9750844ab969c5a74deea9d041701d73f43dfe05465c'
+                '577a83d974064e8')
+        pooch.retrieve(url=download_link, known_hash=hash,
+                       path=data_dir, fname=fname)
+    else:
+        destination = op.join(data_dir, fname)
+        _fetch_file(download_link, destination, print_destination=True,
+                    resume=True, timeout=30.)
 
     # unzip and extract
     # TODO - optionally extract only the missing files


### PR DESCRIPTION
Adds 1d clustering function (only for `adjacency=None` now) and allows `_find_clusters_borsar` to get a list of `thresholds` (`[pos_threshold, neg_threshold]`, this is useful for efficient permutation ttest as stat_fun).