### PR TITLE
DOC/MAINT: massive additions to docs infrastructure

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,11 @@
+Copyright 2018 Mikołaj Magnuski
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Build Status](https://travis-ci.org/mmagnuski/borsar.svg?branch=master)](https://travis-ci.org/mmagnuski/borsar)
-[![Coverage Status](https://codecov.io/gh/mmagnuski/borsar/branch/master/graph/badge.svg)](https://codecov.io/gh/mmagnuski/borsar)   
+[![Coverage Status](https://codecov.io/gh/mmagnuski/borsar/branch/master/graph/badge.svg)](https://codecov.io/gh/mmagnuski/borsar)
 
 Various tools, objects and functions for EEG/MEG data analysis and visualisation. Some functionality that is available here may
 be later moved to [mne-python](https://martinos.org/mne/dev/index.html).
@@ -14,7 +14,7 @@ be later moved to [mne-python](https://martinos.org/mne/dev/index.html).
 
 
 ## Installation
-`borsar` is not yet released on `PPI` so to install you have to download it from Github using pip in the following way:
+`borsar` is not yet released on `PyPI` so to install you have to download it from GitHub using pip in the following way:
 ```
 pip install git+https://github.com/mmagnuski/borsar
 ```
@@ -29,5 +29,5 @@ python setup.py develop
 both methods require you to have [git](https://git-scm.com/) installed.
 
 ## Documentation
-Go to the [online documentation](https://mmagnuski.github.io/borsar.github.io/index.html) for more information about usage examples or full API docs.  
+Go to the [online documentation](https://mmagnuski.github.io/borsar.github.io/index.html) for more information about usage examples or full API docs.
 :construction: be warned that documentation is under contstruction :construction:

--- a/borsar/__init__.py
+++ b/borsar/__init__.py
@@ -1,3 +1,5 @@
+__version__ = '0.1.dev1'
+
 from borsar import (channels, cluster, csd, freq, project, stats, utils, viz)
 
 from borsar.cluster import Clusters, find_clusters, read_cluster

--- a/borsar/cluster/obj.py
+++ b/borsar/cluster/obj.py
@@ -33,7 +33,12 @@ def read_cluster(fname, subjects_dir=None, src=None, info=None):
     clst : Clusters
         Cluster results read from file.
     '''
-    from mne.externals import h5io
+    try:
+        # mne < 1.0
+        from mne.externals import h5io
+    except ModuleNotFoundError:
+        # mne > 1.0 requires separate installation of h5io
+        import h5io
     # subjects_dir = mne.utils.get_subjects_dir(subjects_dir, raise_error=True)
     data_dict = h5io.read_hdf5(fname)
     clst = Clusters(
@@ -187,14 +192,14 @@ class Clusters(object):
             which does not select clusters by p value.
         percentage_in : None | float
             Select clusters by percentage participation in range of the data
-            space specified in **kwargs. For example
+            space specified in ``**kwargs``. For example
             ``clst.select(percentage_in=0.15, freq=(3, 7))`` selects only those
             clusters that have at least 15% of their mass in 3 - 7 Hz frequency
             range. Defaults to None which does not select clusters by their
             participation in data space.
         n_points_in : None | int
             Select clusters by number of their minimum number of data points
-            that lie in the range of the data specified in **kwargs. For
+            that lie in the range of the data specified in ``**kwargs``. For
             example `clst.select(n_points_in=25, time=[0.2, 0.35])` selects
             only those clusters that contain at least 25 points within
             0.2 - 0.35 s time range. Defaults to None which does not select
@@ -225,8 +230,8 @@ class Clusters(object):
             ``percentage_in`` or ``n_points_in``. Otherwise ``*kwargs`` are
             ignored.
 
-        Return
-        ------
+        Returns
+        -------
         clst : borsar.cluster.Clusters
             Selected clusters.
         '''
@@ -341,7 +346,12 @@ class Clusters(object):
             Additional description added when saving. When passed overrides
             the description parameter of Clusters.
         '''
-        from mne.externals import h5io
+        try:
+            # mne < 1.0
+            from mne.externals import h5io
+        except ModuleNotFoundError:
+            # mne > 1.0 requires separate installation of h5io
+            import h5io
 
         if description is None:
             description = self.description

--- a/borsar/cluster/tests/test_cluster.py
+++ b/borsar/cluster/tests/test_cluster.py
@@ -613,8 +613,14 @@ def test_cluster_pvals_and_polarity_sorting():
 
 def test_chan_freq_clusters():
     from mne import create_info
-    from mne.externals import h5io
     import matplotlib.pyplot as plt
+
+    try:
+        # mne < 1.0
+        from mne.externals import h5io
+    except ModuleNotFoundError:
+        # mne > 1.0 requires separate installation of h5io
+        import h5io
 
     fname = op.join(data_dir, 'chan_alpha_range.hdf5')
     data_dict = h5io.read_hdf5(fname)

--- a/borsar/utils.py
+++ b/borsar/utils.py
@@ -118,8 +118,14 @@ def write_info(fname, info, overwrite=False):
     """
     from .channels import get_ch_pos
     from mne.utils import _validate_type
-    from mne.externals import h5io
     from mne.io.pick import channel_indices_by_type
+
+    try:
+        # mne < 1.0
+        from mne.externals import h5io
+    except ModuleNotFoundError:
+        # mne > 1.0 requires separate installation of h5io
+        import h5io
 
     # make sure the types are correct
     _validate_type(fname, 'str', item_name='fname')
@@ -156,10 +162,17 @@ def read_info(fname):
         Info object read from file.
     """
     import mne
+    try:
+        # mne < 1.0
+        from mne.externals import h5io
+    except ModuleNotFoundError:
+        # mne > 1.0 requires separate installation of h5io
+        import h5io
+
     mne.utils._validate_type(fname, 'str', item_name='fname')
 
     # read file
-    data_dict = mne.externals.h5io.read_hdf5(fname)
+    data_dict = h5io.read_hdf5(fname)
     ch_names = data_dict['ch_names']
 
     # parse ch_type
@@ -453,8 +466,7 @@ def download_test_data():
 
     # download the file
     if use_pooch:
-        hash = ('98bab9750844ab969c5a74deea9d041701d73f43dfe05465c'
-                '577a83d974064e8')
+        hash = ('d88b76a6af113f9faefe4ce616ad17cf0a7fbc99f3febdcebfb2b1580eaaaa62')  # noqa: E501
         pooch.retrieve(url=download_link, known_hash=hash,
                        path=data_dir, fname=fname)
     else:

--- a/borsar/viz.py
+++ b/borsar/viz.py
@@ -33,8 +33,8 @@ class Topo(object):
         Topo object that exposes various useful methods like `remove_levels`
         or `mark_channels`.
 
-    Example
-    -------
+    Examples
+    --------
     topo = Topo(values, info, axis=ax)
     topo.remove_levels(0)
     topo.solid_lines()
@@ -204,8 +204,8 @@ class Topo(object):
             each should be updated independently by looping through the
             ``Topo`` object and using ``.update()`` on each element.
 
-        Example
-        -------
+        Examples
+        --------
         # single topography:
         topo = Topo(values, info)
         topo.update(other_values)
@@ -347,7 +347,7 @@ def _extract_topo_channels(ax):
         # if there are no circles: look for PathCollection
         path_collection = ax.findobj(mpl.collections.PathCollection)
         if len(path_collection) > 0:
-            chans = path_collection[0]
+            chans = path_collection[8]
             chan_pos = chans.get_offsets()
         else:
             msg = ('Could not find matplotlib objects representing channels. '

--- a/docs/_templates/class.rst
+++ b/docs/_templates/class.rst
@@ -1,0 +1,12 @@
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. autoclass:: {{ objname }}
+   :special-members: __contains__,__getitem__,__iter__,__len__,__add__,__sub__,__mul__,__div__,__neg__,__hash__
+   :members:
+
+.. _sphx_glr_backreferences_{{ fullname }}:
+
+.. minigallery:: {{ fullname }}
+    :add-heading:

--- a/docs/_templates/function.rst
+++ b/docs/_templates/function.rst
@@ -1,0 +1,10 @@
+{{ fullname | escape | underline}}
+
+.. currentmodule:: {{ module }}
+
+.. autofunction:: {{ objname }}
+
+.. _sphx_glr_backreferences_{{ fullname }}:
+
+.. minigallery:: {{ fullname }}
+    :add-heading:

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 .. _api_documentation:
 
 =================

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -3,25 +3,25 @@
 # Configuration file for the Sphinx documentation builder.
 
 # import sphinx_gallery
+from datetime import date
+
 from numpydoc import docscrape
+import sphinx_bootstrap_theme
 
-
-# add custom styles
-def setup(app):
-    app.add_stylesheet("style.css")
+import borsar
 
 
 # -- Project information -----------------------------------------------------
 
 project = 'borsar'
-copyright = '2018, Mikołaj Magnuski'
+_today = date.today()
+copyright = f'2018-{_today.year}, Mikołaj Magnuski. Last updated {_today.isoformat()}'
 author = 'Mikołaj Magnuski'
 
 # The short X.Y version
-version = '0.1'
+version = borsar.__version__
 # The full version, including alpha/beta/rc tags
-release = '0.1dev'
-
+release = version
 
 # -- General configuration ---------------------------------------------------
 
@@ -46,6 +46,13 @@ extensions = [
 
 # generate autosummary even if no references
 autosummary_generate = True
+
+# set autodoc
+autodoc_default_options = {
+    "members": True,
+    "inherited-members": True,
+    "show-inheritance": True,
+}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -74,6 +81,7 @@ pygments_style = None
 # a list of builtin themes.
 #
 html_theme = 'bootstrap'
+html_theme_path = sphinx_bootstrap_theme.get_html_theme_path()
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -88,6 +96,8 @@ html_theme_options = {
     ],
     'bootswatch_theme': "united"
 }
+
+html_templates_path = ['_templates']
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
@@ -161,27 +171,35 @@ epub_exclude_files = ['search.html']
 
 # configuration for intersphinx: refer to the Python standard library.
 # Example configuration for intersphinx: refer to the Python standard library.
-sns_link = 'https://web.stanford.edu/~mwaskom/software/seaborn/'
-intersphinx_mapping = {'python': ('https://docs.python.org/', None),
-                       'seaborn': (sns_link, None),
-                       'mne': ('http://martinos.org/mne/stable/', None)
+intersphinx_mapping = {'python': ('https://docs.python.org/3', None),
+                       'mne': ('https://mne.tools/dev', None),
+                       'numpy': ('https://numpy.org/devdocs', None),
+                       'scipy': ('https://scipy.github.io/devdocs', None),
+                       'mayavi': (
+                           'http://docs.enthought.com/mayavi/mayavi',
+                           None),
                        }
 
 sphinx_gallery_conf = {
     'examples_dirs': '../examples',
     'gallery_dirs': 'auto_examples',
     'backreferences_dir': 'generated',
-    'reference_url': {
-        'mne': 'http://mne-tools.github.io/stable/',
-        'numpy': 'http://docs.scipy.org/doc/numpy-1.9.1',
-        'scipy': 'http://docs.scipy.org/doc/scipy-0.17.0/reference',
-        'mayavi': 'http://docs.enthought.com/mayavi/mayavi',
-        'borsar': 'http://borsar.github.io/'}
+    'reference_url': {  # noqa: E501 --> https://sphinx-gallery.github.io/stable/configuration.html#add-intersphinx-links-to-your-examples
+        'borsar': None
+    },
 }
 
 # -- numpydoc ----------------------------------------------------------------
 docscrape.ClassDoc.extra_public_methods = (
     '__getitem__', '__iter__', '__len__')
+numpydoc_show_class_members = False  # https://stackoverflow.com/a/34604043/5201771
 numpydoc_class_members_toctree = False
-numpydoc_attributes_as_param_list = False
 numpydoc_xref_param_type = True
+numpydoc_attributes_as_param_list = False
+numpydoc_xref_ignore = {
+    # words
+    "of",
+    "or",
+    "shape",
+    "optional",
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,7 +15,8 @@ import borsar
 
 project = 'borsar'
 _today = date.today()
-copyright = f'2018-{_today.year}, Mikołaj Magnuski. Last updated {_today.isoformat()}'
+iso_date = _today.isoformat()
+copyright = f'2018-{_today.year}, Mikołaj Magnuski. Last updated {iso_date}'
 author = 'Mikołaj Magnuski'
 
 # The short X.Y version
@@ -192,7 +193,8 @@ sphinx_gallery_conf = {
 # -- numpydoc ----------------------------------------------------------------
 docscrape.ClassDoc.extra_public_methods = (
     '__getitem__', '__iter__', '__len__')
-numpydoc_show_class_members = False  # https://stackoverflow.com/a/34604043/5201771
+# https://stackoverflow.com/a/34604043/5201771
+numpydoc_show_class_members = False
 numpydoc_class_members_toctree = False
 numpydoc_xref_param_type = True
 numpydoc_attributes_as_param_list = False

--- a/environment.yml
+++ b/environment.yml
@@ -1,4 +1,4 @@
-name: base
+name: borsar
 channels:
 - defaults
 dependencies:
@@ -27,3 +27,5 @@ dependencies:
   - neo
   - pydocstyle
   - codespell
+  - sphinx_gallery
+  - sphinx_bootstrap_theme

--- a/examples/plot_cluster_viz.py
+++ b/examples/plot_cluster_viz.py
@@ -22,8 +22,9 @@ download_test_data()
 # Let's first create the info object:
 
 import mne
-mntg = mne.channels.read_montage('easycap-M1')
-info = mne.create_info(mntg.ch_names, sfreq=250., ch_types='eeg', montage=mntg)
+mntg = mne.channels.make_standard_montage('easycap-M1')
+info = mne.create_info(mntg.ch_names, sfreq=250., ch_types='eeg')
+info = info.set_montage(mntg)
 
 ###############################################################################
 # Now we read the file.

--- a/setup.py
+++ b/setup.py
@@ -9,15 +9,24 @@ import os
 import os.path as op
 from setuptools import setup
 
+version = None
+with open('borsar/__init__.py', 'r') as fid:
+    for line in fid:
+        line = line.strip()
+        if line.startswith('__version__ = '):
+            version = line.split(' = ')[1].split('#')[0].strip('\'')
+            break
+if version is None:
+    raise RuntimeError('Could not determine version')
+
 
 DISTNAME = 'borsar'
 DESCRIPTION = "Tools for (mostly eeg) data analysis with mne-python."
 MAINTAINER = u'Mikołaj Magnuski'
 MAINTAINER_EMAIL = 'mmagnuski@swps.edu.pl'
 URL = 'https://github.com/mmagnuski/borsar'
-LICENSE = 'BSD (3-clause)'
+LICENSE = 'BSD-3-Clause'
 DOWNLOAD_URL = 'https://github.com/mmagnuski/borsar'
-VERSION = '0.1dev1'
 
 
 def package_tree(pkgroot):
@@ -37,7 +46,7 @@ if __name__ == "__main__":
           description=DESCRIPTION,
           license=LICENSE,
           url=URL,
-          version=VERSION,
+          version=version,
           download_url=DOWNLOAD_URL,
           long_description=open('README.md').read(),
           zip_safe=False,  # the package can run out of an .egg file


### PR DESCRIPTION
closes #27
related to #94 (one step on that way, but automated building and deploying is still needed)

based on your request from https://github.com/mne-tools/mne-python/issues/10604#issuecomment-1120391100 I gave this a shot. With the present changes, the docs build without errors or warnings and you get a proper documentation for methods, akin to how it is in pyprep: see e.g., https://pyprep.readthedocs.io/en/latest/generated/pyprep.NoisyChannels.html#pyprep.NoisyChannels

The only thing that feels hacky to me and where I am a bit uncertain is in viz.py, where the index changed from 0 to 8 to get plotted markers. --- But somehow that was needed to make the example build. 

I hope you don't feel that this is too invasive. :-)

