### PR TITLE
ENH: add option to return permutation vectors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,11 +27,6 @@ jobs:
             source activate borsar
             mamba env update -n borsar -f environment.yml -v
 
-            echo "=== DEBUG PYTHON VERSION ==="
-            which python
-            python -V
-            mamba env export -n borsar | grep "^python="
-
             if [ << parameters.use_numba >> == "yes" ]; then
               mamba install numba -y;
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
           name: Create conda env
           command: |
             if [ "<< parameters.mne_version >>" == "1.4.0" ]; then
-              PY_VERSION="3.10"
+              PY_VERSION="3.11"
             else
               PY_VERSION="3.13"
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,8 +17,16 @@ jobs:
       - run:
           name: Create conda env
           command: |
-            mamba env create -f environment.yml
+            if [ "<< parameters.mne_version >>" == "1.4.0" ]; then
+              PY_VERSION="3.9"
+            else
+              PY_VERSION="3.13"
+            fi
+
+            mamba create -n borsar python=$PY_VERSION -y
             source activate borsar
+            mamba env update -n borsar -f environment.yml
+
             if [ << parameters.use_numba >> == "yes" ]; then
               mamba install numba -y;
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,4 +46,4 @@ workflows:
           matrix:
             parameters:
               use_numba: ["yes", "no"]
-              mne_version: ["1.9.0", "1.5.0", "1.1.0"]
+              mne_version: ["1.10.2", "1.8.0", "1.4.0"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ jobs:
           name: Create conda env
           command: |
             if [ "<< parameters.mne_version >>" == "1.4.0" ]; then
-              PY_VERSION="3.9"
+              PY_VERSION="3.10"
             else
               PY_VERSION="3.13"
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,9 @@ jobs:
             else
               pip install mne==<< parameters.mne_version >>;
             fi
+            if [ "<< parameters.mne_version >>" == "1.4.0" ]; then
+              mamba install "matplotlib==3.3.4" -y
+            fi
             pip install tqdm
             hash -r pytest
       - run:
@@ -46,4 +49,4 @@ workflows:
           matrix:
             parameters:
               use_numba: ["yes", "no"]
-              mne_version: ["1.10.2", "1.8.0", "1.4.0"]
+              mne_version: ["current", "1.8.0", "1.4.0"]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,9 +23,14 @@ jobs:
               PY_VERSION="3.13"
             fi
 
-            mamba create -n borsar python=$PY_VERSION -y
+            mamba create -n borsar python=$PY_VERSION -y -v
             source activate borsar
-            mamba env update -n borsar -f environment.yml
+            mamba env update -n borsar -f environment.yml -v
+
+            echo "=== DEBUG PYTHON VERSION ==="
+            which python
+            python -V
+            mamba env export -n borsar | grep "^python="
 
             if [ << parameters.use_numba >> == "yes" ]; then
               mamba install numba -y;

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ jobs:
               pip install mne==<< parameters.mne_version >>;
             fi
             if [ "<< parameters.mne_version >>" == "1.4.0" ]; then
-              mamba install "matplotlib==3.3.4" -y
+              mamba install "matplotlib==3.10" -y
             fi
             pip install tqdm
             hash -r pytest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,15 +17,8 @@ jobs:
       - run:
           name: Create conda env
           command: |
-            if [ "<< parameters.mne_version >>" == "1.4.0" ]; then
-              PY_VERSION="3.11"
-            else
-              PY_VERSION="3.13"
-            fi
-
-            mamba create -n borsar python=$PY_VERSION -y -v
+            mamba env create -f environment.yml
             source activate borsar
-            mamba env update -n borsar -f environment.yml -v
 
             if [ << parameters.use_numba >> == "yes" ]; then
               mamba install numba -y;

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,11 @@ jobs:
       - run:
           name: Create conda env
           command: |
-            mamba env create -f environment.yml
+            if [ "<< parameters.mne_version >>" == "1.4.0" ]; then
+              mamba env create -f environment_mpl.yml
+            else
+              mamba env create -f environment.yml
+            fi
             source activate borsar
 
             if [ << parameters.use_numba >> == "yes" ]; then
@@ -27,9 +31,6 @@ jobs:
               pip install mne
             else
               pip install mne==<< parameters.mne_version >>;
-            fi
-            if [ "<< parameters.mne_version >>" == "1.4.0" ]; then
-              mamba install "matplotlib==3.10" -y
             fi
             pip install tqdm
             hash -r pytest

--- a/borsar/_mne_compat.py
+++ b/borsar/_mne_compat.py
@@ -4,8 +4,7 @@ from mne.viz.topomap import _plot_topomap
 
 from packaging import version
 mne_version = version.parse(mne.__version__)
-has_1_1 = mne_version >= version.parse('1.1.dev0')
-has_1_2 = mne_version >= version.parse('1.2.dev0')
+has_1_4 = mne_version >= version.parse('1.4.dev0')
 
 _BORDER_DEFAULT = 'mean'
 _EXTRAPOLATE_DEFAULT = 'box'
@@ -15,20 +14,19 @@ _EXTRAPOLATE_DEFAULT = 'box'
 #                                present in docdict)
 @fill_doc
 def plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
-                 res=64, axes=None, names=None, show_names=False, mask=None,
+                 res=64, axes=None, names=None, mask=None,
                  mask_params=None, outlines='head', contours=6,
-                 image_interp='bilinear', show=True, onselect=None,
+                 image_interp='cubic', show=True, onselect=None,
                  extrapolate=_EXTRAPOLATE_DEFAULT, sphere=None,
                  border=_BORDER_DEFAULT, ch_type='eeg', cnorm=None):
     """Plot a topographic map as image.
     (docs as in mne)
     """
     sphere = _check_sphere(sphere)
-    if has_1_2 or has_1_1:
-        if image_interp == 'bilinear':
-            image_interp = 'cubic'
+    if image_interp == 'bilinear':
+        image_interp = 'cubic'
 
-    if has_1_2:
+    if has_1_4:
         return _plot_topomap(
             data, pos, vmin=vmin, vmax=vmax, cmap=cmap, sensors=sensors,
             res=res, axes=axes, names=names, mask=mask,
@@ -36,11 +34,6 @@ def plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
             image_interp=image_interp, show=show, onselect=onselect,
             extrapolate=extrapolate, sphere=sphere, border=border,
             ch_type=ch_type, cnorm=cnorm)
-    elif has_1_1:
-        return _plot_topomap(data, pos, vmin, vmax, cmap, sensors, res, axes,
-                             names, show_names, mask, mask_params, outlines,
-                             contours, image_interp, show, onselect,
-                             extrapolate, sphere=sphere, border=border,
-                             ch_type=ch_type)
     else:
-        raise RuntimeError('You need to have MNE-Python version >= 1.1.0')
+        raise RuntimeError('You need to have MNE-Python version >= 1.4.0')
+

--- a/borsar/_mne_compat.py
+++ b/borsar/_mne_compat.py
@@ -36,4 +36,3 @@ def plot_topomap(data, pos, vmin=None, vmax=None, cmap=None, sensors=True,
             ch_type=ch_type, cnorm=cnorm)
     else:
         raise RuntimeError('You need to have MNE-Python version >= 1.4.0')
-

--- a/borsar/stats.py
+++ b/borsar/stats.py
@@ -141,7 +141,8 @@ def _compute_threshold_via_permutations(data, paired, tail, stat_fun,
     '''
     Compute significance thresholds using permutations.
 
-    Assumes ``n_conditions x n_observations x ...`` data array.
+    Assumes ``n_conditions x n_observations x ...`` data array or a list of
+    ``n_observations x ...`` arrays (one per condition).
     Note that the permutations are implemented via shuffling of the condition
     labels, not randomization of independent condition orders.
 

--- a/borsar/stats.py
+++ b/borsar/stats.py
@@ -243,7 +243,7 @@ def _compute_threshold_via_permutations(data, paired, tail, stat_fun,
         raise ValueError(f'Unrecognized tail "{tail}"')
 
     if not return_distribution and not return_permutations:
-        return stats
+        return threshold
 
     output = [threshold]
 

--- a/borsar/tests/test_stats.py
+++ b/borsar/tests/test_stats.py
@@ -183,6 +183,37 @@ def test_compute_threshold_via_permutations():
         assert np.abs(error) < 0.15
 
 
+def test_compute_threshold_via_permutations_perm_vectors():
+
+    n_cond = 4
+    n_obs = 15
+    n_rest = (20, 20)
+    shape = (n_cond,) + (n_obs,) + n_rest
+    data = np.random.rand(*shape)
+
+    stat_fun = _find_stat_fun(n_cond, False, 'pos')
+    stats, dist, perms = _compute_threshold_via_permutations(
+        data, paired=False, tail='pos', stat_fun=stat_fun,
+        return_permutations=True, return_distribution=True
+    )
+
+    # test if we can recreate stats map for a randomly chosen permutation
+    perm_idx_to_test = np.random.randint(0, high=1_000)
+    calc_dist = dist[perm_idx_to_test]
+
+    # recalculate the f values for given permutation vector
+    # (the loop below could maybe be simplified or exposed in borsar)
+    data_perm = list()
+    data_resh = data.reshape((n_cond * n_obs,) + n_rest)
+    for cond_idx in range(n_cond):
+        msk = perms[perm_idx_to_test] == cond_idx
+        data_perm.append(data_resh[msk, :])
+
+    fvals_perm = stat_fun(*data_perm)
+
+    assert (calc_dist == fvals_perm).all()
+
+
 def test_compute_threshold_via_permutations_n_jobs():
     '''Thresholds computed with different number of jobs should be similar.'''
     data = [np.random.randn(12, 10, 10), np.random.randn(12, 10, 10)]

--- a/borsar/tests/test_stats.py
+++ b/borsar/tests/test_stats.py
@@ -174,11 +174,11 @@ def test_compute_threshold_via_permutations():
         avg_perm = np.abs(permutation_threshold).mean()
         error = analytical_threshold - avg_perm
 
-        print('paired:', paired)
-        print('analytical_threshold:', analytical_threshold)
-        print('permutation threshold:', permutation_threshold)
-        print('average permutation threshold:', avg_perm)
-        print('difference:', error)
+        # print('paired:', paired)
+        # print('analytical_threshold:', analytical_threshold)
+        # print('permutation threshold:', permutation_threshold)
+        # print('average permutation threshold:', avg_perm)
+        # print('difference:', error)
 
         assert np.abs(error) < 0.15
 

--- a/borsar/tests/test_viz.py
+++ b/borsar/tests/test_viz.py
@@ -87,7 +87,11 @@ def test_multi_topo():
 
     linewidths = list()
     for lines in tp.lines:
-        linewidths.append(lines.get_linewidths())
+        if hasattr(lines, 'collections'):
+            for line in lines.collections:
+                linewidths.append(line.get_linewidths()[0])
+        else:
+            linewidths.append(lines.get_linewidths())
     assert (np.concatenate(linewidths) == 0.35).all()
 
     # other tests

--- a/borsar/tests/test_viz.py
+++ b/borsar/tests/test_viz.py
@@ -87,9 +87,8 @@ def test_multi_topo():
 
     linewidths = list()
     for lines in tp.lines:
-        for line in lines.collections:
-            linewidths.append(line.get_linewidths()[0])
-    assert (np.array(linewidths) == 0.35).all()
+        linewidths.append(lines.get_linewidths())
+    assert (np.concatenate(linewidths) == 0.35).all()
 
     # other tests
     tp.solid_lines()

--- a/borsar/tests/test_viz.py
+++ b/borsar/tests/test_viz.py
@@ -92,7 +92,12 @@ def test_multi_topo():
                 linewidths.append(line.get_linewidths()[0])
         else:
             linewidths.append(lines.get_linewidths())
-    assert (np.concatenate(linewidths) == 0.35).all()
+    try:
+        linewidths = np.concatenate(linewidths)
+    except ValueError:
+        linewidths = np.asarray(linewidths)
+
+    assert (linewidths == 0.35).all()
 
     # other tests
     tp.solid_lines()

--- a/borsar/utils.py
+++ b/borsar/utils.py
@@ -492,7 +492,8 @@ def download_test_data():
                      'AABCak4jORjgridWwHlwjhMHa?dl=1')
 
     # download the file
-    hash = '43afe405bb842170e883e460ca1fc6a4e5c6ac4c0a7af0ccc52405fb0d70b31c'
+    hash = ('43afe405bb842170e883e460ca1fc6a4e5c6ac4c0a7af0ccc52405f'
+            'b0d70b31c')  # noqa: E501
     pooch.retrieve(url=download_link, known_hash=hash,
                    path=data_dir, fname=fname)
 

--- a/borsar/viz.py
+++ b/borsar/viz.py
@@ -1,7 +1,6 @@
 from copy import copy
 import numpy as np
 import matplotlib.pyplot as plt
-from matplotlib.contour import QuadContourSet
 
 from .channels import get_ch_pos
 from ._heatmap import heatmap
@@ -168,7 +167,8 @@ class Topo(object):
             Keyword arguments are passed to `set_linestyle` of each line.
         '''
         for topo in self:
-            if isinstance(topo.lines, QuadContourSet):
+
+            if not hasattr(topo.lines, 'collections'):
                 topo.lines.set_linestyles(*args, **kwargs)
             else:
                 for line in topo.lines.collections:
@@ -194,7 +194,7 @@ class Topo(object):
         '''
         for topo in self:
             if contours is not None:
-                if isinstance(topo.lines, QuadContourSet):
+                if not hasattr(topo.lines, 'collections'):
                     topo.lines.set_linewidths(contours)
                 else:
                     for line in topo.lines.collections:
@@ -262,7 +262,7 @@ class Topo(object):
             if hasattr(topo, 'head'):
                 [line.set_clip_on(True) for line in topo.head]
 
-            if isinstance(topo.lines, QuadContourSet):
+            if not hasattr(topo.lines, 'collections'):
                 topo.lines.set_clip_on(True)
             else:
                 [line.set_clip_on(True) for line in topo.lines.collections]
@@ -308,8 +308,11 @@ class Topo(object):
         self.img.set_data(new_image)
 
         # update contour lines by removing the old ...
-        for l in self.lines.collections:
-            l.remove()
+        if hasattr(self.lines, 'collections'):
+            for l in self.lines.collections:
+                l.remove()
+        else:
+            self.lines.remove()
 
         # ... and drawing new ones
         # FIXME - make line properties (lw) remembered
@@ -320,8 +323,11 @@ class Topo(object):
 
         # reapply clipping to the contours
         patch = self.mask_patch
-        for l in self.lines.collections:
-            l.set_clip_path(patch)
+        if hasattr(self.lines, 'collections'):
+            for l in self.lines.collections:
+                l.set_clip_path(patch)
+        else:
+            self.lines.set_clip_path(patch)
 
     def __len__(self):
         '''Return number of topomaps in Topo.'''

--- a/borsar/viz.py
+++ b/borsar/viz.py
@@ -180,8 +180,11 @@ class Topo(object):
         '''
         for topo in self:
             if contours is not None:
-                for line in topo.lines.collections:
-                    line.set_linewidths(contours)
+                if isinstance(topo.lines, QuadContourSet):
+                    topo.lines.set_linewidths(contours)
+                else:
+                    for line in topo.lines.collections:
+                        line.set_linewidths(contours)
             if outlines is not None:
                 for line in topo.head:
                     line.set_linewidth(outlines)
@@ -244,7 +247,11 @@ class Topo(object):
 
             if hasattr(topo, 'head'):
                 [line.set_clip_on(True) for line in topo.head]
-            [line.set_clip_on(True) for line in topo.lines.collections]
+
+            if isinstance(topo.lines, QuadContourSet):
+                topo.lines.set_clip_on(True)
+            else:
+                [line.set_clip_on(True) for line in topo.lines.collections]
 
     def update(self, values):
         '''

--- a/borsar/viz.py
+++ b/borsar/viz.py
@@ -129,7 +129,7 @@ class Topo(object):
 
         iter_lines = (self.lines if isinstance(self.lines, list)
                       else [self.lines])
-        has_collections = hasattr(lines, 'collections')
+        has_collections = hasattr(iter_lines[0], 'collections')
         for lines in iter_lines:
             if has_collections:
                 for l in lvl:

--- a/borsar/viz.py
+++ b/borsar/viz.py
@@ -181,7 +181,7 @@ class Topo(object):
     # TODO: keywords: contours=x, outline=y,
     def set_linewidth(self, contours=None, outlines=None):
         '''
-        Set contour lines line width.
+        Set line width of the contour lines or the head outline.
 
         Parameters
         ----------

--- a/borsar/viz.py
+++ b/borsar/viz.py
@@ -129,14 +129,24 @@ class Topo(object):
 
         iter_lines = (self.lines if isinstance(self.lines, list)
                       else [self.lines])
-
+        has_collections = hasattr(lines, 'collections')
         for lines in iter_lines:
-            for l in lvl:
-                remove_lines = np.where(lines.levels == l)[0]
-                for rem_ln in remove_lines:
-                    lines.collections[rem_ln].remove()
-                for pop_ln in np.flipud(np.sort(remove_lines)):
-                    lines.collections.pop(pop_ln)
+            if has_collections:
+                for l in lvl:
+                    remove_lines = np.where(lines.levels == l)[0]
+                    for rem_ln in remove_lines:
+                        lines.collections[rem_ln].remove()
+                    for pop_ln in np.flipud(np.sort(remove_lines)):
+                        lines.collections.pop(pop_ln)
+            else:
+                # New matplotlib (>= 3.8): .collections attribute does not
+                # exist, we need to try a less elegant approach of changing
+                # linewidth to 0 for the lines we would like to no longer be visible
+                linewidths = [0 if level in lvl else lines.get_linewidth()[i] 
+                              if hasattr(lines.get_linewidth(), '__getitem__')
+                              else lines.get_linewidth()
+                              for i, level in enumerate(lines.levels)]
+                lines.set_linewidth(linewidths)
 
     def solid_lines(self):
         '''Turn all contour lines to solid style (no dashed lines).'''

--- a/borsar/viz.py
+++ b/borsar/viz.py
@@ -143,9 +143,12 @@ class Topo(object):
                 # exist, we need to try a less elegant approach of changing
                 # linewidth to 0 for the lines we would like to no longer be
                 # visible (maybe this could be done with .set_visible()?)
+                n_levels = len(lines.levels)
                 msk = np.isin(lines.levels, lvl)
                 if msk.any():
                     linewidths = np.asarray(lines.get_linewidths())
+                    if len(linewidths) == 1 and n_levels > 1:
+                        linewidths = np.repeat(linewidths[0], n_levels)
                     linewidths[msk] = 0
                     lines.set_linewidths(linewidths)
 

--- a/borsar/viz.py
+++ b/borsar/viz.py
@@ -141,12 +141,13 @@ class Topo(object):
             else:
                 # New matplotlib (>= 3.8): .collections attribute does not
                 # exist, we need to try a less elegant approach of changing
-                # linewidth to 0 for the lines we would like to no longer be visible
-                linewidths = [0 if level in lvl else lines.get_linewidth()[i] 
-                              if hasattr(lines.get_linewidth(), '__getitem__')
-                              else lines.get_linewidth()
-                              for i, level in enumerate(lines.levels)]
-                lines.set_linewidth(linewidths)
+                # linewidth to 0 for the lines we would like to no longer be
+                # visible (maybe this could be done with .set_visible()?)
+                msk = np.isin(lines.levels, lvl)
+                if msk.any():
+                    linewidths = np.asarray(lines.get_linewidths())
+                    linewidths[msk] = 0
+                    lines.set_linewidths(linewidths)
 
     def solid_lines(self):
         '''Turn all contour lines to solid style (no dashed lines).'''

--- a/environment.yml
+++ b/environment.yml
@@ -2,10 +2,9 @@ name: borsar
 channels:
 - defaults
 dependencies:
-- python
 - pip
-- mkl>=2021.4.0
-- numpy>=1.20.1
+- mkl
+- numpy
 - scipy
 - matplotlib
 - pandas
@@ -14,7 +13,7 @@ dependencies:
 - scikit-image
 - h5py
 # dev/testing libraries:
-- statsmodels>=0.13.2
+- statsmodels
 - pytest
 - pytest-cov
 - psutil

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: borsar
 channels:
 - defaults
 dependencies:
-- python>=3.13
+- python=3.13
 - pip
 - mkl
 - numpy

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: borsar
 channels:
 - defaults
 dependencies:
-- python>=3.13
+- python
 - pip
 - mkl>=2021.4.0
 - numpy>=1.20.1

--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,7 @@ dependencies:
 - mkl>=2021.4.0
 - numpy>=1.20.1
 - scipy
-- matplotlib==3.8.4
+- matplotlib
 - pandas
 - xlrd
 - scikit-learn

--- a/environment.yml
+++ b/environment.yml
@@ -2,6 +2,7 @@ name: borsar
 channels:
 - defaults
 dependencies:
+- python>=3.13
 - pip
 - mkl
 - numpy

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: borsar
 channels:
 - defaults
 dependencies:
-- python=3.13
+- python>=3.13
 - pip
 - mkl
 - numpy

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: borsar
 channels:
 - defaults
 dependencies:
-- python>=3.10
+- python>=3.13
 - pip
 - mkl>=2021.4.0
 - numpy>=1.20.1

--- a/environment_mpl.yml
+++ b/environment_mpl.yml
@@ -2,12 +2,12 @@ name: borsar
 channels:
 - defaults
 dependencies:
-- python>=3.13
+- python=3.13
 - pip
 - mkl
 - numpy
 - scipy
-- matplotlib=3.10
+- matplotlib=3.9
 - pandas
 - xlrd
 - scikit-learn

--- a/environment_mpl.yml
+++ b/environment_mpl.yml
@@ -1,0 +1,31 @@
+name: borsar
+channels:
+- defaults
+dependencies:
+- python>=3.13
+- pip
+- mkl
+- numpy
+- scipy
+- matplotlib=3.10
+- pandas
+- xlrd
+- scikit-learn
+- scikit-image
+- h5py
+# dev/testing libraries:
+- statsmodels
+- pytest
+- pytest-cov
+- psutil
+- numpydoc
+- flake8
+# likely not needed:
+- joblib
+- pip:
+  - mne
+  - h5io
+  - pydocstyle
+  - codespell
+  - sphinx_gallery
+  - sphinx_bootstrap_theme


### PR DESCRIPTION
Permutation vectors allow to reconstruct the permutation data used by the permutation test.
One use case is for testing single-cell stimulus selectivity when we want the cell to pass multiple criteria (multiple statistical tests or a statistical test plus additional criteria). We can then apply the same criteria to the permutation distribution by reconstructing the permutation data.

This PR also:
* fixes remaining issues with QuadContourSet in borsar.viz.Topo (on newer matplotlib versions) - fixes #132
* changes the CI tests to use both older and newer matplotlib and increase coverage